### PR TITLE
Improvement controller lane 2b: charter v2 delta (records, settings, guards, docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -358,7 +358,7 @@ FEATURES__MAX_CRITIQUE_CYCLES=
 # either way, so flipping it needs no re-registration. The other IMPROVEMENT__* knobs (concurrency, daily
 # paid-inference dollars, weekly infrastructure dollars, the budget day and
 # week boundaries, tick cadence) are documented on their fields in
-# config/settings.py and are not declared here — they are tuning, not
+# config/settings.py and are not declared here: they are tuning, not
 # enablement.
 # @optional
 IMPROVEMENT__ENABLED=

--- a/.env.example
+++ b/.env.example
@@ -356,9 +356,10 @@ FEATURES__MAX_CRITIQUE_CYCLES=
 # evidence row, so a registered tick is not a running writer. Set to true only
 # on the machine that owns the `valor` project; the reflection stays registered
 # either way, so flipping it needs no re-registration. The other IMPROVEMENT__* knobs (concurrency, daily
-# external-LLM dollars, portfolio allocation, tick cadence) are documented on
-# their fields in config/settings.py and are not declared here — they are
-# tuning, not enablement.
+# paid-inference dollars, weekly infrastructure dollars, the budget day and
+# week boundaries, tick cadence) are documented on their fields in
+# config/settings.py and are not declared here — they are tuning, not
+# enablement.
 # @optional
 IMPROVEMENT__ENABLED=
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,7 +10,7 @@ import logging.handlers
 import os
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -583,11 +583,15 @@ class ImprovementSettings(BaseModel):
     ``docs/plans/recursive-self-improvement.md`` fails the build if a question
     path reappears anywhere in bridge/, tools/, config/, models/, or ui/.
 
-    Budget is two units, neither of them a per-experiment dollar ceiling for
-    Claude. Claude work runs on the subscription and is budgeted as SDLC lane
-    concurrency; external LLM calls run through the existing OpenRouter path
-    against a daily dollar pool, settled per call from reported usage, with the
-    controller and the evaluator drawing separate reservations from it.
+    Budget is three separately reserved units, none of them a per-experiment
+    dollar ceiling for Claude. Claude work runs on the subscription and is
+    budgeted as SDLC lane concurrency. Paid inference on other models runs
+    through the existing OpenRouter path against a daily dollar pool, settled
+    per call from reported usage, with the controller and the evaluator drawing
+    separate reservations from it. Infrastructure — sandboxes, storage,
+    Cloudflare — draws on a weekly dollar pool of its own. The day and week
+    boundaries are disclosed rather than assumed, because a reservation that
+    resets on an undisclosed boundary cannot be audited.
 
     Every default here is PROVISIONAL/TUNABLE. ``enabled`` defaults to False:
     nothing in this system runs until it is deliberately turned on.
@@ -615,26 +619,47 @@ class ImprovementSettings(BaseModel):
             "Env: IMPROVEMENT__MAX_CONCURRENT_RESEARCH_SESSIONS."
         ),
     )
-    daily_external_llm_usd: float = Field(
+    daily_paid_inference_usd: float = Field(
         default=10.00,
         ge=0.0,
         description=(
-            "Daily dollar pool for non-Claude LLM calls through the OpenRouter "
-            "path, settled per call from the usage reported in each response "
-            "envelope. The controller and the evaluator draw separate "
-            "reservations from this one pool, so a runaway research loop "
-            "cannot starve the evaluator that would catch it. "
-            "PROVISIONAL/TUNABLE. Env: IMPROVEMENT__DAILY_EXTERNAL_LLM_USD."
+            "Daily dollar pool for paid inference on non-Claude models through "
+            "the OpenRouter path, settled per call from the usage reported in "
+            "each response envelope. The controller and the evaluator draw "
+            "separate reservations from this one pool, so a runaway research "
+            "loop cannot starve the evaluator that would catch it. "
+            "PROVISIONAL/TUNABLE. Env: IMPROVEMENT__DAILY_PAID_INFERENCE_USD."
         ),
     )
-    portfolio_allocation: str = Field(
-        default="architectural=0.5,stakeholder=0.25,quality=0.25",
+    weekly_infrastructure_usd: float = Field(
+        default=50.00,
+        ge=0.0,
         description=(
-            "How research effort is split across the three charter objectives, "
-            "as comma-separated ``objective=weight`` pairs. Read as a "
-            "portfolio, not a target: an objective starved for several cycles "
-            "is a signal to look at, not a quota to fill. PROVISIONAL/TUNABLE. "
-            "Env: IMPROVEMENT__PORTFOLIO_ALLOCATION."
+            "Weekly dollar pool for the infrastructure the loop runs on: "
+            "sandboxes, storage, and Cloudflare. Reserved separately from paid "
+            "inference and on a different window, because a week is the unit a "
+            "sandbox or a storage bucket is actually billed and reasoned about "
+            "in. PROVISIONAL/TUNABLE. "
+            "Env: IMPROVEMENT__WEEKLY_INFRASTRUCTURE_USD."
+        ),
+    )
+    budget_day_boundary: Literal["UTC"] = Field(
+        default="UTC",
+        description=(
+            "The timezone whose midnight ends a budget day. Disclosed rather "
+            "than assumed: a reservation that resets on an undisclosed "
+            "boundary cannot be audited against what was actually spent. "
+            "PROVISIONAL/TUNABLE. Env: IMPROVEMENT__BUDGET_DAY_BOUNDARY."
+        ),
+    )
+    budget_week_start: Literal["monday", "sunday"] = Field(
+        default="monday",
+        description=(
+            "The weekday a budget week begins on, for the infrastructure pool. "
+            "Disclosed for the same reason as the day boundary, and typed so a "
+            "bad override fails at settings load rather than at the first "
+            "window computation. PROVISIONAL/TUNABLE. "
+            "Env: IMPROVEMENT__BUDGET_WEEK_START."
         ),
     )
     controller_tick_seconds: int = Field(

--- a/config/settings.py
+++ b/config/settings.py
@@ -588,8 +588,8 @@ class ImprovementSettings(BaseModel):
     budgeted as SDLC lane concurrency. Paid inference on other models runs
     through the existing OpenRouter path against a daily dollar pool, settled
     per call from reported usage, with the controller and the evaluator drawing
-    separate reservations from it. Infrastructure — sandboxes, storage,
-    Cloudflare — draws on a weekly dollar pool of its own. The day and week
+    separate reservations from it. Infrastructure (sandboxes, storage,
+    Cloudflare) draws on a weekly dollar pool of its own. The day and week
     boundaries are disclosed rather than assumed, because a reservation that
     resets on an undisclosed boundary cannot be audited.
 

--- a/docs/features/improvement-controller.md
+++ b/docs/features/improvement-controller.md
@@ -172,7 +172,7 @@ Turning it back off is the same edit in reverse; no hand edit of the vault
 Three budget units, reserved separately, and one of them is not money: Claude
 work runs on the subscription and is budgeted as lane concurrency. The window
 boundaries are settings rather than assumptions because charter §8 requires them
-disclosed — a reservation that resets on an undisclosed boundary cannot be
+disclosed: a reservation that resets on an undisclosed boundary cannot be
 audited against what was actually spent.
 
 **Nothing meters dollars today.** Both dollar figures are declared limits with
@@ -196,12 +196,13 @@ question path reappears.
 ## Charter
 
 `docs/improvement-charter.md` is the north star. Tom owns it and only Tom edits
-it; nothing in `models/`, `tools/`, `reflections/`, or `ui/` writes that file,
-and it is on the candidate-surface denylist.
+it; nothing in `models/`, `tools/`, `reflections/`, or `ui/` writes that file.
+Lane 6 (#3218) adds the candidate-surface denylist that refuses it as a
+candidate.
 
 `ImprovementCharter.load_from_file` projects the file into a record. It digests
-the bytes with `tools/sdlc_verdict.py::compute_plan_hash`, which normalizes CRLF
-to LF, so the same charter digests identically on any checkout. It **refuses**
+the bytes with the same CRLF-to-LF normalization `tools/sdlc_verdict.py::compute_plan_hash`
+applies, so the same charter digests identically on any checkout. It **refuses**
 any file whose frontmatter names an owner other than `Tom Counsell`, returning
 None and writing nothing.
 
@@ -312,7 +313,7 @@ Three panels on the root dashboard.
 the work is ranked under, the §3 early priorities marked as starting hypotheses
 rather than an allocation, open cases with their `priority_area` and
 `ranking_rationale`, and unresolved assumptions. Every heading no lane writes
-yet says so and names the lane that will fill it — acquired abilities and
+yet says so and names the lane that will fill it: acquired abilities and
 resource use come with lane 3, evaluations with lane 4, rejected approaches with
 lane 5. Each section renders one of three distinguishable states: content,
 "nothing yet, written by lane N", or "unavailable" when the read failed. A bare

--- a/docs/features/improvement-controller.md
+++ b/docs/features/improvement-controller.md
@@ -7,6 +7,7 @@ deserves to exist.
 Tracking issue: [#3177](https://github.com/tomcounsell/ai/issues/3177).
 Plan: [`docs/plans/recursive-self-improvement.md`](../plans/recursive-self-improvement.md).
 Current state: [capability matrix](../plans/critiques/recursive-self-improvement-capability-matrix.md).
+North star: [`docs/improvement-charter.md`](../improvement-charter.md), which Tom owns and only Tom edits.
 
 ## What exists today
 
@@ -162,16 +163,80 @@ Turning it back off is the same edit in reverse; no hand edit of the vault
 |---|---|---|
 | `enabled` | `False` | Master switch. `IMPROVEMENT__ENABLED` |
 | `max_concurrent_research_sessions` | `1` | Claude work is budgeted as SDLC lane concurrency, not dollars: the subscription is the constraint |
-| `daily_external_llm_usd` | `10.00` | Daily pool for non-Claude calls through OpenRouter, settled per call from reported usage; controller and evaluator draw separate reservations |
-| `portfolio_allocation` | `architectural=0.5,stakeholder=0.25,quality=0.25` | How effort splits across the charter objectives. A portfolio, not a quota |
+| `daily_paid_inference_usd` | `10.00` | Daily pool for paid inference on non-Claude models through OpenRouter; controller and evaluator draw separate reservations |
+| `weekly_infrastructure_usd` | `50.00` | Weekly pool for sandboxes, storage, and Cloudflare, charter §8's second spending category |
+| `budget_day_boundary` | `UTC` | The timezone whose midnight ends a budget day |
+| `budget_week_start` | `monday` | The weekday an infrastructure budget week begins on |
 | `controller_tick_seconds` | `900` | Cadence, matching the registered reflection |
 
-**There is no `daily_question_ceiling`.** The ceiling is zero and the capability
-does not exist. The controller asks Tom nothing: it resolves uncertainty from
-Tom-sourced memories and online research, and records what it cannot resolve as
-a provisional assumption with its evidence, shown on the dashboard as an
-assumption rather than a fact. A Verification row in the plan fails the build if
-a question path reappears.
+Three budget units, reserved separately, and one of them is not money: Claude
+work runs on the subscription and is budgeted as lane concurrency. The window
+boundaries are settings rather than assumptions because charter §8 requires them
+disclosed — a reservation that resets on an undisclosed boundary cannot be
+audited against what was actually spent.
+
+**Nothing meters dollars today.** Both dollar figures are declared limits with
+no meter behind them; `tools/paid_inference_meter.py` arrives with lane 3.
+Uncertain metering is not zero cost.
+
+**There is no fixed allocation across areas.** Ranking is by expected
+contribution to the north star (charter §3), recorded per case as
+`ranking_rationale` beside the `priority_area` and the charter digest it was
+ranked under. The eleven-value `PRIORITY_AREAS` vocabulary is a classification,
+not a quota.
+
+**There is no `daily_question_ceiling`.** Charter §9 forbids routine research
+questions: the controller resolves uncertainty from Tom-sourced memories and
+online research, and records what it cannot resolve as a provisional assumption
+with its evidence, shown on the dashboard as an assumption rather than a fact.
+One message class is permitted, the evidence-backed charter amendment request,
+and it arrives with lane 3. A Verification row fails the build if a routine
+question path reappears.
+
+## Charter
+
+`docs/improvement-charter.md` is the north star. Tom owns it and only Tom edits
+it; nothing in `models/`, `tools/`, `reflections/`, or `ui/` writes that file,
+and it is on the candidate-surface denylist.
+
+`ImprovementCharter.load_from_file` projects the file into a record. It digests
+the bytes with `tools/sdlc_verdict.py::compute_plan_hash`, which normalizes CRLF
+to LF, so the same charter digests identically on any checkout. It **refuses**
+any file whose frontmatter names an owner other than `Tom Counsell`, returning
+None and writing nothing.
+
+The record is append-only. One immutable row per unseen digest; an amended
+charter adds a row and leaves the earlier one exactly as it was, because an
+evaluation or release that cites a charter must still resolve it years later.
+The loader never calls `save()` on an existing row, never flips a prior row to
+`superseded`, and never deletes. `ImprovementCharter.pinned(project_key)` is the
+charter in force: the newest row by `created_at`.
+
+`digest` is a plain field rather than an index. The schema gate rejects an
+indexed field whose name marks it unbounded, so the loader matches the digest in
+Python over the project's charter rows, which number one per version.
+
+`ImprovementCase`, `ImprovementInvestigation`, and `ImprovementRelease` each
+carry `charter_digest`, so a decision records the exact charter text it was
+admitted under. The version is the human-readable name; the digest is the
+identity.
+
+## Provider eligibility and resources
+
+`tools/improvement_eligibility.py::is_open_source(project_key)` is the charter
+§7 guard: any provider may see open-source work, and client work stays on the
+Claude and Codex subscriptions. It **fails closed to client** on every
+uncertainty, and it passes the repository to `gh` positionally, because
+`GH_REPO` is set process-wide and `gh` reads it before cwd. Its cache is
+process-local rather than a Redis key, and caches only determinate answers.
+
+`tools/improvement_resources.py::probe()` is the charter §8 verification: each
+named resource is reported `verified`, `absent`, or `unknown`. `unknown` is the
+default on any uncertainty, never `absent`, because reporting a resource absent
+when it exists sends the next lane out to acquire something already in the
+vault. Presence comes from `op item list` titles, which carry no field values;
+where a fingerprint is wanted the credential is hashed immediately and reported
+as `sha256:<hex>`. The probe never raises and never emits a credential.
 
 ## Control namespace contract (lane 3)
 
@@ -241,7 +306,19 @@ content without a path heuristic.
 
 ## Dashboard
 
-Two panels on the root dashboard, both backed by `ImprovementEvidence`.
+Three panels on the root dashboard.
+
+**Goals** is the charter §11 readable record: which charter version and digest
+the work is ranked under, the §3 early priorities marked as starting hypotheses
+rather than an allocation, open cases with their `priority_area` and
+`ranking_rationale`, and unresolved assumptions. Every heading no lane writes
+yet says so and names the lane that will fill it — acquired abilities and
+resource use come with lane 3, evaluations with lane 4, rejected approaches with
+lane 5. Each section renders one of three distinguishable states: content,
+"nothing yet, written by lane N", or "unavailable" when the read failed. A bare
+zero would claim a measurement was taken.
+
+The other two panels are backed by `ImprovementEvidence`.
 
 **Coverage** comes first and is the denominator. A falling correction count with
 a falling scan count is not an improvement, and coverage is what makes the two
@@ -252,8 +329,8 @@ count below it is a count of nothing, rather than showing a comforting zero.
 raw count beside every share. `unknown` is expected to be the largest bucket.
 An empty window reads as "nothing observed", never "nothing happened".
 
-`ui/data/improvement.py` exports exactly three getters, and a test pins that
-list. **Experiment count and merged-patch count are activity, not improvement**,
+`ui/data/improvement.py` exports exactly four getters, and a test pins that
+list as an exact list. **Experiment count and merged-patch count are activity, not improvement**,
 and there is deliberately no function here that returns them.
 
 Cases, hypotheses, rejected experiments, spend, release lineage, and the

--- a/docs/features/improvement-controller.md
+++ b/docs/features/improvement-controller.md
@@ -12,7 +12,7 @@ North star: [`docs/improvement-charter.md`](../improvement-charter.md), which To
 ## What exists today
 
 Lanes 1 and 2. The records, the settings, the evidence collection tick, the
-verifying artifact store, and two dashboard panels. The control journal, the
+verifying artifact store, and three dashboard panels. The control journal, the
 research sessions, the evaluation harness, and releases arrive with lanes 3
 through 6, each as its own child issue.
 

--- a/docs/plans/critiques/recursive-self-improvement-capability-matrix.md
+++ b/docs/plans/critiques/recursive-self-improvement-capability-matrix.md
@@ -66,18 +66,18 @@ entries (`bridge/dispatch.py::_append_inbound_chat_log`) and `Memory` rows with
 read — its only assigner has no production caller, which would reproduce the
 exact defect the table below records as retired.
 
-## Lane 2b — charter v2 delta
+## Lane 2b: charter v2 delta
 
 | Component | Implemented | Deployed | Measured | Effect |
 |---|---|---|---|---|
-| `ImprovementCharter.digest` / `effective` / `text` | yes | yes (schema is live once merged) | no | n/a — storage, not behavior |
-| `ImprovementCharter.load_from_file` seed | yes | no caller yet — lane 3's tick is the first | no | unknown |
+| `ImprovementCharter.digest` / `effective` / `text` | yes | yes (schema is live once merged) | no | n/a (storage, not behavior) |
+| `ImprovementCharter.load_from_file` seed | yes | no caller yet (lane 3's tick is the first) | no | unknown |
 | `ImprovementCharter.pinned` | yes | read by the goals partial | no | n/a |
-| `PRIORITY_AREAS` + `priority_area` / `ranking_rationale` | yes | no writer yet — lane 3 opens the first case | no | n/a |
+| `PRIORITY_AREAS` + `priority_area` / `ranking_rationale` | yes | no writer yet (lane 3 opens the first case) | no | n/a |
 | `charter_digest` on case, investigation, release | yes | no writer yet | no | n/a |
 | `objective` deleted | yes | yes, no rows existed | n/a | n/a |
-| Three budget units in `ImprovementSettings` | yes | yes, defaults only | **no** | n/a — declared limits, nothing meters them |
-| `is_open_source` charter §7 guard | yes | no caller yet — lane 3 routes the first session | no | unknown |
+| Three budget units in `ImprovementSettings` | yes | yes, defaults only | **no** | n/a (declared limits, nothing meters them) |
+| `is_open_source` charter §7 guard | yes | no caller yet (lane 3 routes the first session) | no | unknown |
 | `probe()` charter §8 verification | yes | run by hand, see below | **yes, once** | n/a |
 | Goals partial (`/_partials/improvement/goals/`) | yes | yes | no | n/a |
 | `confirm_improvement_v2_fields` migration | yes | on the next `/update` per machine | no | n/a |

--- a/docs/plans/critiques/recursive-self-improvement-capability-matrix.md
+++ b/docs/plans/critiques/recursive-self-improvement-capability-matrix.md
@@ -66,6 +66,49 @@ entries (`bridge/dispatch.py::_append_inbound_chat_log`) and `Memory` rows with
 read — its only assigner has no production caller, which would reproduce the
 exact defect the table below records as retired.
 
+## Lane 2b — charter v2 delta
+
+| Component | Implemented | Deployed | Measured | Effect |
+|---|---|---|---|---|
+| `ImprovementCharter.digest` / `effective` / `text` | yes | yes (schema is live once merged) | no | n/a — storage, not behavior |
+| `ImprovementCharter.load_from_file` seed | yes | no caller yet — lane 3's tick is the first | no | unknown |
+| `ImprovementCharter.pinned` | yes | read by the goals partial | no | n/a |
+| `PRIORITY_AREAS` + `priority_area` / `ranking_rationale` | yes | no writer yet — lane 3 opens the first case | no | n/a |
+| `charter_digest` on case, investigation, release | yes | no writer yet | no | n/a |
+| `objective` deleted | yes | yes, no rows existed | n/a | n/a |
+| Three budget units in `ImprovementSettings` | yes | yes, defaults only | **no** | n/a — declared limits, nothing meters them |
+| `is_open_source` charter §7 guard | yes | no caller yet — lane 3 routes the first session | no | unknown |
+| `probe()` charter §8 verification | yes | run by hand, see below | **yes, once** | n/a |
+| Goals partial (`/_partials/improvement/goals/`) | yes | yes | no | n/a |
+| `confirm_improvement_v2_fields` migration | yes | on the next `/update` per machine | no | n/a |
+
+**The resource probe's measured result**, run on Tom's MacBook Air at build
+time. This is one machine at one moment, not a fleet statement.
+
+| Resource | State | Why |
+|---|---|---|
+| `workspace_personal` | unknown | the `m-valor` vault listing could not be read |
+| `workspace_work` | unknown | same |
+| `virtual_debit_card` | unknown | same |
+| `cloudflare_account` | unknown | same |
+| `cloudflare_cli` | absent | `wrangler` is not installed on this machine |
+| `vault_write` | absent | the sanctioned vault writer is lane 3's and does not exist |
+
+The four `unknown`s are an environment result, not a vault result. `op` is
+installed but `OP_SERVICE_ACCOUNT_TOKEN` was not set in the build shell, so the
+CLI fell back to an interactive prompt and the probe's timeout bounded it. That
+is exactly why `unknown` and `absent` are separate states: reporting these four
+absent would send lane 3 out to acquire accounts that may well already exist.
+Re-run the probe under the service-account token before treating any of them as
+missing.
+
+**The honest reading of this lane.** It corrects vocabulary and adds two guards
+with no callers. Nothing here changes behavior on merge day: the guards are
+libraries lane 3 consumes, the seed has no caller, and the goals partial renders
+mostly empty sections that name the lane which will fill each. The one thing it
+does change is that the settings and the feature doc stop describing decisions
+the charter withdrew.
+
 ## Retired instrumentation
 
 | Component | Status | Why |

--- a/models/improvement_case.py
+++ b/models/improvement_case.py
@@ -9,10 +9,9 @@ Schema (schema-gate ruling for ``docs/plans/recursive-self-improvement.md``):
 - Three IndexedFields, all low-cardinality: ``state`` (seven values, see
   :data:`CASE_STATES`), ``priority`` (four values), and ``priority_area``
   (eleven values, see :data:`PRIORITY_AREAS`). They are three orthogonal
-  readings of one case — lifecycle, urgency, and charter §3 classification —
-  and the goals partial reads all three. ``revision`` is an ``IntField`` and is
-  deliberately not indexed — it grows without bound, and neither is
-  ``charter_digest``.
+  readings of one case (lifecycle, urgency, and charter §3 classification),
+  and the goals partial reads all three. ``revision`` (an ``IntField``) and
+  ``charter_digest`` are deliberately not indexed: both are unbounded.
 - **The projection is not the authority.** The control journal's Redis head
   holds the authoritative state and revision; this row is the queryable
   projection of it, updated through ORM ``save()`` after the journal commits.

--- a/models/improvement_case.py
+++ b/models/improvement_case.py
@@ -6,9 +6,13 @@ Schema (schema-gate ruling for ``docs/plans/recursive-self-improvement.md``):
   ``project_key`` (``KeyField``) for the partition. A single recency
   ``SortedField(created_at, partition_by="project_key")`` serves the "open
   cases for this project" read without an unbounded index.
-- Two IndexedFields, both low-cardinality: ``state`` (seven values, see
-  :data:`CASE_STATES`) and ``priority`` (four values). ``revision`` is an
-  ``IntField`` and is deliberately not indexed — it grows without bound.
+- Three IndexedFields, all low-cardinality: ``state`` (seven values, see
+  :data:`CASE_STATES`), ``priority`` (four values), and ``priority_area``
+  (eleven values, see :data:`PRIORITY_AREAS`). They are three orthogonal
+  readings of one case — lifecycle, urgency, and charter §3 classification —
+  and the goals partial reads all three. ``revision`` is an ``IntField`` and is
+  deliberately not indexed — it grows without bound, and neither is
+  ``charter_digest``.
 - **The projection is not the authority.** The control journal's Redis head
   holds the authoritative state and revision; this row is the queryable
   projection of it, updated through ORM ``save()`` after the journal commits.
@@ -52,6 +56,24 @@ CASE_STATES: tuple[str, ...] = (
 #: Bounded priority vocabulary.
 CASE_PRIORITIES: tuple[str, ...] = ("urgent", "high", "normal", "low")
 
+#: Charter §3's classification of what a case is trying to improve. Five come
+#: from the charter's priority list and five from its closing sentence naming
+#: the eligible means; ``other`` is what keeps the set from reading as a fixed
+#: allocation. Orthogonal to :data:`CASE_PRIORITIES`, which is urgency.
+PRIORITY_AREAS: tuple[str, ...] = (
+    "inference",
+    "token_efficiency",
+    "skills",
+    "personas",
+    "cloud_execution",
+    "research_process",
+    "evaluators",
+    "memory",
+    "orchestration",
+    "infrastructure",
+    "other",
+)
+
 
 class ImprovementCase(Model):
     """A weakness the system is pursuing, with its lineage.
@@ -72,7 +94,10 @@ class ImprovementCase(Model):
         evidence_ids: JSON list of ``ImprovementEvidence`` ids.
         job_id: The ``Job`` carrying the intended outcome, when one exists.
         charter_version: The charter version in force when the case was opened.
-        objective: Which charter objective this case serves.
+        charter_digest: The ``sha256:<hex>`` of the charter the case was ranked
+            under. The version is the human-readable name; this is the identity.
+        priority_area: One of :data:`PRIORITY_AREAS`. Low-cardinality index.
+        ranking_rationale: Why this case sits where it does in the order.
         updated_at: Last projection write.
     """
 
@@ -81,6 +106,7 @@ class ImprovementCase(Model):
     created_at = SortedField(type=datetime, partition_by="project_key")
     state = IndexedField(default="observed")
     priority = IndexedField(default="normal")
+    priority_area = IndexedField(default="other")
     revision = IntField(default=0)
     title = Field(null=True)
     summary = Field(null=True)
@@ -88,5 +114,6 @@ class ImprovementCase(Model):
     evidence_ids = Field(null=True)
     job_id = Field(null=True)
     charter_version = IntField(default=0)
-    objective = Field(null=True)
+    charter_digest = Field(null=True)
+    ranking_rationale = Field(null=True)
     updated_at = Field(null=True)

--- a/models/improvement_case.py
+++ b/models/improvement_case.py
@@ -52,6 +52,16 @@ CASE_STATES: tuple[str, ...] = (
     "paused",  # break-glass, needs a human hand
 )
 
+#: The states that end a case's life. ``paused`` is deliberately absent: it is
+#: break-glass, a case waiting on a human hand, and still open work.
+TERMINAL_CASE_STATES: tuple[str, ...] = ("released", "rejected")
+
+#: The states a case is still open in. Derived from :data:`CASE_STATES` rather
+#: than listed, so adding a state to the lifecycle cannot leave the two sets
+#: disagreeing about what "open" means. Readers query the ``state`` index one
+#: value at a time from this tuple instead of hydrating the partition.
+OPEN_CASE_STATES: tuple[str, ...] = tuple(s for s in CASE_STATES if s not in TERMINAL_CASE_STATES)
+
 #: Bounded priority vocabulary.
 CASE_PRIORITIES: tuple[str, ...] = ("urgent", "high", "normal", "low")
 

--- a/models/improvement_charter.py
+++ b/models/improvement_charter.py
@@ -59,7 +59,6 @@ from popoto import (
 from popoto.fields.content_field import ContentField
 
 from models.verifying_artifact_store import verifying_artifact_store
-from tools.sdlc_verdict import compute_plan_hash
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +178,12 @@ class ImprovementCharter(Model):
         would need an atomic primitive in a control namespace that does not
         exist yet.
         """
+        # Imported inside the method, not at module scope. `tools.sdlc_verdict`
+        # reaches `agent.sdlc_router`, which imports `agent/__init__`, which
+        # imports `models/__init__` — so a module-level import here closes a
+        # cycle that breaks any process importing the SDLC tools first.
+        from tools.sdlc_verdict import compute_plan_hash
+
         path = Path(path)
         digest = compute_plan_hash(path)
         if digest is None:

--- a/models/improvement_charter.py
+++ b/models/improvement_charter.py
@@ -12,11 +12,20 @@ Schema (schema-gate ruling for ``docs/plans/recursive-self-improvement.md``):
   ``version`` is an ``IntField`` and is deliberately **not** indexed: it grows
   without bound, so an index on it is exactly the anti-pattern the gate exists
   to stop. Version lookups go through the recency sort plus a Python filter.
-- **Charter versions are immutable.** Amending the charter appends a new row
-  and flips the previous row's ``state`` to ``superseded``; a row is never
-  edited in place. The controller cannot write this model at all — amending
-  its own objectives, authority, or budgets is outside every authority it
-  holds. Only a human, through ``valor-improve`` or a migration, writes a
+  ``digest`` is a plain ``Field`` for the same reason: the index guard rejects
+  any indexed field whose name marks it unbounded, so :meth:`load_from_file`
+  matches the digest in Python over the project's charter rows.
+- **Charter versions are immutable, and loading appends.**
+  :meth:`load_from_file` projects ``docs/improvement-charter.md`` into one row
+  per unseen digest. It creates or it returns what is already there; it never
+  calls ``save()`` on an existing row, never flips a prior row's ``state``, and
+  never deletes. An amended charter therefore produces a second ``active`` row
+  and leaves the first exactly as it was, which is what keeps an old release
+  auditable against the charter it was admitted under. ``state`` keeps its
+  two-value vocabulary for a human-driven supersede later; the loader simply
+  never writes it. The controller cannot write this model at all — amending its
+  own objectives, authority, or budgets is outside every authority it holds.
+  Only a human, through the charter file itself or a migration, writes a
   charter.
 - **TTL decision: immortal, no ``Meta.ttl``.** The charter is the record of
   what the system was authorized to do at the time it acted. An evaluation or
@@ -32,8 +41,11 @@ human-approved scope on top of them. See
 
 from __future__ import annotations
 
-from datetime import datetime
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
 
+import yaml
 from popoto import (
     AutoKeyField,
     DatetimeField,
@@ -44,10 +56,56 @@ from popoto import (
     Model,
     SortedField,
 )
+from popoto.fields.content_field import ContentField
+
+from models.verifying_artifact_store import verifying_artifact_store
+from tools.sdlc_verdict import compute_plan_hash
+
+logger = logging.getLogger(__name__)
 
 #: The two values ``state`` may hold. Kept as a module constant so the index
 #: cardinality is checkable by a test rather than by reading prose.
 CHARTER_STATES: tuple[str, ...] = ("active", "superseded")
+
+#: The only human who owns the charter. A file naming anyone else is refused.
+CHARTER_OWNER = "Tom Counsell"
+
+#: The charter file, anchored to this module's own checkout rather than to the
+#: process cwd. Callers start from different directories — a reflection tick, a
+#: FastAPI process, a ``.worktrees/`` checkout — and a cwd-relative default
+#: would seed a different file, or none, per caller while a missing file
+#: returns None silently.
+_CHARTER_PATH = Path(__file__).resolve().parents[1] / "docs" / "improvement-charter.md"
+
+
+def _parse_frontmatter(text: str) -> dict | None:
+    """Return the YAML frontmatter mapping, or None if there is not one.
+
+    None covers all three unusable shapes: no opening fence, no closing fence,
+    and a block that is not a mapping. Malformed YAML raises, and the caller
+    treats that the same way.
+    """
+    if not text.startswith("---"):
+        return None
+    closing = text.find("\n---", 3)
+    if closing == -1:
+        return None
+    parsed = yaml.safe_load(text[3:closing])
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _recency(row) -> float:
+    """A row's ``created_at`` as a comparable float.
+
+    Rows read back from Redis may carry a naive datetime; treating those as UTC
+    keeps the sort total instead of raising on a naive/aware comparison.
+    """
+    value = getattr(row, "created_at", None)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.timestamp()
+    return 0.0
 
 
 class ImprovementCharter(Model):
@@ -59,6 +117,11 @@ class ImprovementCharter(Model):
         created_at: Recency sort, partitioned by ``project_key``.
         state: ``active`` | ``superseded``. Low-cardinality index.
         version: Monotonic version counter. Not indexed (unbounded).
+        digest: ``sha256:<hex>`` of the charter file, CRLF-normalized. The
+            row's real identity. Not indexed (see the module docstring).
+        effective: The date this charter version took effect, as written in
+            the file's frontmatter.
+        text: The charter's full text, on the verifying artifact store.
         scope: JSON describing the authorized research surfaces.
         authority: JSON describing what the controller may decide alone.
         budgets: JSON snapshot of the budget units this version authorizes.
@@ -72,9 +135,104 @@ class ImprovementCharter(Model):
     created_at = SortedField(type=datetime, partition_by="project_key")
     state = IndexedField(default="active")
     version = IntField(default=1)
+    digest = Field(null=True)
+    effective = Field(null=True)
+    text = ContentField(store=verifying_artifact_store)
     scope = Field(null=True)
     authority = Field(null=True)
     budgets = Field(null=True)
     approved_by = Field(null=True)
     approved_at = DatetimeField(null=True)
     notes = Field(null=True)
+
+    @classmethod
+    def load_from_file(
+        cls,
+        path: Path = _CHARTER_PATH,
+        project_key: str = "valor",
+    ) -> ImprovementCharter | None:
+        """Seed one immutable charter row from the charter file.
+
+        Returns the row for this file's digest: the existing one when the
+        digest has been seen, a newly created one when it has not, and None
+        when the file cannot be read, carries no usable frontmatter, or names
+        an owner other than ``Tom Counsell``. Nothing is written on any None
+        path.
+
+        Append-only. An amended charter adds a row; the earlier row keeps every
+        field it had, ``state`` included. Reading the pinned charter is
+        :meth:`pinned`, not a ``state`` filter.
+
+        A missing or non-numeric ``version`` does not refuse the seed. The
+        digest is the identity and a version number is a display detail; only
+        ``owner`` refuses.
+
+        The default ``path`` is anchored to this module's checkout, so a
+        worktree seeds its own branch's charter. The controller tick runs from
+        a main checkout and therefore pins main's charter.
+
+        Tolerated race: the digest lookup and the ``create()`` are not atomic,
+        so two simultaneous callers can both miss and both create. Duplicate
+        rows for one digest are harmless — rows are immutable and identical for
+        a given digest — and :meth:`pinned` resolves by newest ``created_at``
+        regardless of how many share a digest. Making this a compare-and-set
+        would need an atomic primitive in a control namespace that does not
+        exist yet.
+        """
+        path = Path(path)
+        digest = compute_plan_hash(path)
+        if digest is None:
+            logger.warning("improvement charter: unreadable at %s; not seeding", path)
+            return None
+
+        try:
+            frontmatter = _parse_frontmatter(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, yaml.YAMLError) as e:
+            logger.warning("improvement charter: frontmatter unparseable at %s: %s", path, e)
+            return None
+        if frontmatter is None:
+            logger.warning("improvement charter: no usable frontmatter at %s", path)
+            return None
+
+        if frontmatter.get("owner") != CHARTER_OWNER:
+            logger.warning(
+                "improvement charter: %s declares owner %r, not %r; refusing to seed",
+                path,
+                frontmatter.get("owner"),
+                CHARTER_OWNER,
+            )
+            return None
+
+        for row in cls.query.filter(project_key=project_key):
+            if getattr(row, "digest", None) == digest:
+                return row
+
+        fields: dict = {
+            "project_key": project_key,
+            "created_at": datetime.now(UTC),
+            "state": "active",
+            "digest": digest,
+            "text": path.read_text(encoding="utf-8"),
+        }
+        effective = frontmatter.get("effective")
+        if effective is not None:
+            fields["effective"] = str(effective)
+        try:
+            fields["version"] = int(frontmatter["version"])
+        except (KeyError, TypeError, ValueError):
+            logger.warning(
+                "improvement charter: %s has no usable version; seeding with the default", path
+            )
+        return cls.create(**fields)
+
+    @classmethod
+    def pinned(cls, project_key: str = "valor") -> ImprovementCharter | None:
+        """The charter in force: the newest row in this project's partition.
+
+        Newest by ``created_at``, which is the rule whether or not two rows
+        share a digest. Returns None when nothing has been seeded.
+        """
+        rows = list(cls.query.filter(project_key=project_key))
+        if not rows:
+            return None
+        return max(rows, key=_recency)

--- a/models/improvement_charter.py
+++ b/models/improvement_charter.py
@@ -180,11 +180,9 @@ class ImprovementCharter(Model):
         exist yet.
         """
         # The digest, frontmatter, and text all come from one buffer read here,
-        # inside the try. Three separate reads used to run: a file edited
-        # between them could yield a stored `text` that does not hash to its
-        # `digest`, and the third read sat outside the try so a mid-read OSError
-        # propagated instead of honoring this docstring's "None when the file
-        # cannot be read" contract.
+        # inside the try: a stored `text` always hashes to its stored `digest`,
+        # and any read error honors this docstring's "None when the file cannot
+        # be read" contract.
         path = Path(path)
         try:
             raw = path.read_bytes()

--- a/models/improvement_charter.py
+++ b/models/improvement_charter.py
@@ -23,7 +23,7 @@ Schema (schema-gate ruling for ``docs/plans/recursive-self-improvement.md``):
   and leaves the first exactly as it was, which is what keeps an old release
   auditable against the charter it was admitted under. ``state`` keeps its
   two-value vocabulary for a human-driven supersede later; the loader simply
-  never writes it. The controller cannot write this model at all — amending its
+  never writes it. The controller cannot write this model at all: amending its
   own objectives, authority, or budgets is outside every authority it holds.
   Only a human, through the charter file itself or a migration, writes a
   charter.
@@ -41,6 +41,7 @@ human-approved scope on top of them. See
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -70,8 +71,8 @@ CHARTER_STATES: tuple[str, ...] = ("active", "superseded")
 CHARTER_OWNER = "Tom Counsell"
 
 #: The charter file, anchored to this module's own checkout rather than to the
-#: process cwd. Callers start from different directories — a reflection tick, a
-#: FastAPI process, a ``.worktrees/`` checkout — and a cwd-relative default
+#: process cwd. Callers start from different directories (a reflection tick, a
+#: FastAPI process, a ``.worktrees/`` checkout), and a cwd-relative default
 #: would seed a different file, or none, per caller while a missing file
 #: returns None silently.
 _CHARTER_PATH = Path(__file__).resolve().parents[1] / "docs" / "improvement-charter.md"
@@ -147,7 +148,7 @@ class ImprovementCharter(Model):
     @classmethod
     def load_from_file(
         cls,
-        path: Path = _CHARTER_PATH,
+        path: Path | str = _CHARTER_PATH,
         project_key: str = "valor",
     ) -> ImprovementCharter | None:
         """Seed one immutable charter row from the charter file.
@@ -172,32 +173,36 @@ class ImprovementCharter(Model):
 
         Tolerated race: the digest lookup and the ``create()`` are not atomic,
         so two simultaneous callers can both miss and both create. Duplicate
-        rows for one digest are harmless — rows are immutable and identical for
-        a given digest — and :meth:`pinned` resolves by newest ``created_at``
+        rows for one digest are harmless: rows are immutable and identical for
+        a given digest, and :meth:`pinned` resolves by newest ``created_at``
         regardless of how many share a digest. Making this a compare-and-set
         would need an atomic primitive in a control namespace that does not
         exist yet.
         """
-        # Imported inside the method, not at module scope. `tools.sdlc_verdict`
-        # reaches `agent.sdlc_router`, which imports `agent/__init__`, which
-        # imports `models/__init__` — so a module-level import here closes a
-        # cycle that breaks any process importing the SDLC tools first.
-        from tools.sdlc_verdict import compute_plan_hash
-
+        # The digest, frontmatter, and text all come from one buffer read here,
+        # inside the try. Three separate reads used to run: a file edited
+        # between them could yield a stored `text` that does not hash to its
+        # `digest`, and the third read sat outside the try so a mid-read OSError
+        # propagated instead of honoring this docstring's "None when the file
+        # cannot be read" contract.
         path = Path(path)
-        digest = compute_plan_hash(path)
-        if digest is None:
-            logger.warning("improvement charter: unreadable at %s; not seeding", path)
-            return None
-
         try:
-            frontmatter = _parse_frontmatter(path.read_text(encoding="utf-8"))
+            raw = path.read_bytes()
+            text = raw.decode("utf-8")
+            frontmatter = _parse_frontmatter(text)
         except (OSError, UnicodeDecodeError, yaml.YAMLError) as e:
-            logger.warning("improvement charter: frontmatter unparseable at %s: %s", path, e)
+            logger.warning("improvement charter: unreadable at %s: %s", path, e)
             return None
         if frontmatter is None:
             logger.warning("improvement charter: no usable frontmatter at %s", path)
             return None
+
+        # Same normalization tools.sdlc_verdict.compute_plan_hash applies (CRLF
+        # and stray CR collapse to LF before hashing), reused here as a formula
+        # instead of a second file read: a CRLF checkout of the charter digests
+        # identically to an LF one.
+        normalized = raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+        digest = f"sha256:{hashlib.sha256(normalized).hexdigest()}"
 
         if frontmatter.get("owner") != CHARTER_OWNER:
             logger.warning(
@@ -217,7 +222,7 @@ class ImprovementCharter(Model):
             "created_at": datetime.now(UTC),
             "state": "active",
             "digest": digest,
-            "text": path.read_text(encoding="utf-8"),
+            "text": text,
         }
         effective = frontmatter.get("effective")
         if effective is not None:

--- a/models/improvement_investigation.py
+++ b/models/improvement_investigation.py
@@ -74,6 +74,8 @@ class ImprovementInvestigation(Model):
         expires_at: When these claims should stop being trusted.
         cost_usd: External-LLM dollars this investigation settled against the
             daily reservation.
+        charter_digest: The ``sha256:<hex>`` of the charter in force when this
+            investigation was admitted. Not indexed (unbounded).
     """
 
     id = AutoKeyField()
@@ -89,6 +91,7 @@ class ImprovementInvestigation(Model):
     interpretation = Field(null=True)
     expires_at = DatetimeField(null=True)
     cost_usd = Field(null=True)
+    charter_digest = Field(null=True)
 
     class Meta:
         # 30 days, matching ReflectionRun. Retrieval-dated external claims

--- a/models/improvement_release.py
+++ b/models/improvement_release.py
@@ -64,6 +64,8 @@ class ImprovementRelease(Model):
         approved_by: The human who approved it, when one has.
         approved_at: When they approved it.
         outcome: What actually happened during the observation window.
+        charter_digest: The ``sha256:<hex>`` of the charter this release was
+            admitted under. Not indexed (unbounded).
     """
 
     id = AutoKeyField()
@@ -79,3 +81,4 @@ class ImprovementRelease(Model):
     approved_by = Field(null=True)
     approved_at = DatetimeField(null=True)
     outcome = Field(null=True)
+    charter_digest = Field(null=True)

--- a/scripts/update/migrations.py
+++ b/scripts/update/migrations.py
@@ -1427,6 +1427,50 @@ def _migrate_confirm_improvement_models_readable(project_dir: Path) -> str | Non
         return str(e)
 
 
+def _migrate_confirm_improvement_v2_fields(project_dir: Path) -> str | None:
+    """Confirm the charter-v2 fields on the Improvement* models (issue #3255).
+
+    Purely additive to four existing models: ``ImprovementCharter`` gains
+    ``digest``, ``effective``, and ``text``; ``ImprovementCase`` gains
+    ``priority_area``, ``ranking_rationale``, and ``charter_digest``;
+    ``ImprovementInvestigation`` and ``ImprovementRelease`` gain
+    ``charter_digest``. The one removal, ``ImprovementCase.objective``, was a
+    plain unindexed field with no writer, so there is nothing to backfill and
+    no index set to strip.
+
+    This entry exists so ``run_pending_migrations()`` carries a durable marker
+    for the schema version that introduced the v2 vocabulary — without it there
+    is no record on a machine that the charter-digest fields were ever
+    registered, and a later subtractive migration has no predecessor to reason
+    from.
+
+    Read-only: it imports each class and runs one bounded, project-scoped query
+    per model to prove the keyspace resolves under the new fields. Writes
+    nothing. Returns None on success, error string on unexpected failure.
+    """
+    try:
+        import sys
+
+        sys.path.insert(0, str(project_dir))
+        from models import (
+            ImprovementCase,
+            ImprovementCharter,
+            ImprovementInvestigation,
+            ImprovementRelease,
+        )
+
+        for model in (
+            ImprovementCharter,
+            ImprovementCase,
+            ImprovementInvestigation,
+            ImprovementRelease,
+        ):
+            list(model.query.filter(project_key="valor"))[:1]
+        return None
+    except Exception as e:
+        return str(e)
+
+
 MIGRATIONS: dict[str, tuple[callable, str]] = {
     "side_effect_job_model": (
         _migrate_side_effect_job_model,
@@ -1558,6 +1602,12 @@ MIGRATIONS: dict[str, tuple[callable, str]] = {
     "confirm_improvement_models_readable": (
         _migrate_confirm_improvement_models_readable,
         "Register the eight additive Improvement* models (issue #3177) and "
+        "confirm their keyspace resolves",
+    ),
+    "confirm_improvement_v2_fields": (
+        _migrate_confirm_improvement_v2_fields,
+        "Register the charter-v2 fields on ImprovementCharter, ImprovementCase, "
+        "ImprovementInvestigation, and ImprovementRelease (issue #3255) and "
         "confirm their keyspace resolves",
     ),
     "backfill_job_last_active_scores": (

--- a/scripts/update/migrations.py
+++ b/scripts/update/migrations.py
@@ -1381,50 +1381,54 @@ def _migrate_retire_task_type_profile(project_dir: Path) -> str | None:
     )
 
 
+def _confirm_models_readable(project_dir: Path, model_names: tuple[str, ...]) -> str | None:
+    """Import each named model from ``models`` and prove its keyspace resolves.
+
+    Shared by every additive-schema marker migration below, so a new marker is
+    just a new model-name tuple rather than a second copy of this body.
+    Read-only: for each name it imports the class and pulls at most one row
+    from a project-scoped query, without hydrating the rest of the partition.
+    Writes nothing. Returns None on success, error string on unexpected
+    failure.
+    """
+    try:
+        import importlib
+        import sys
+
+        sys.path.insert(0, str(project_dir))
+        models_module = importlib.import_module("models")
+        for name in model_names:
+            model = getattr(models_module, name)
+            next(iter(model.query.filter(project_key="valor")), None)
+        return None
+    except Exception as e:
+        return str(e)
+
+
 def _migrate_confirm_improvement_models_readable(project_dir: Path) -> str | None:
     """Confirm the eight new Improvement* models (issue #3177) import and read.
 
     Purely additive: eight brand-new model classes, no field added to and no
     field removed from an existing model, so there is nothing to backfill and
     no index set to strip. This entry exists so ``run_pending_migrations()``
-    carries a durable marker for the schema version that introduced them —
+    carries a durable marker for the schema version that introduced them:
     without it there is no record on a machine that the improvement keyspace
     was ever registered, and a later subtractive migration has no predecessor
     to reason from.
-
-    Read-only: it imports each class and runs one bounded, project-scoped
-    query per model to prove the keyspace resolves. Writes nothing. Returns
-    None on success, error string on unexpected failure.
     """
-    try:
-        import sys
-
-        sys.path.insert(0, str(project_dir))
-        from models import (
-            ImprovementCase,
-            ImprovementCharter,
-            ImprovementEvaluation,
-            ImprovementEvidence,
-            ImprovementExperiment,
-            ImprovementInvestigation,
-            ImprovementModelRevision,
-            ImprovementRelease,
-        )
-
-        for model in (
-            ImprovementCharter,
-            ImprovementEvidence,
-            ImprovementModelRevision,
-            ImprovementCase,
-            ImprovementInvestigation,
-            ImprovementExperiment,
-            ImprovementEvaluation,
-            ImprovementRelease,
-        ):
-            list(model.query.filter(project_key="valor"))[:1]
-        return None
-    except Exception as e:
-        return str(e)
+    return _confirm_models_readable(
+        project_dir,
+        (
+            "ImprovementCharter",
+            "ImprovementEvidence",
+            "ImprovementModelRevision",
+            "ImprovementCase",
+            "ImprovementInvestigation",
+            "ImprovementExperiment",
+            "ImprovementEvaluation",
+            "ImprovementRelease",
+        ),
+    )
 
 
 def _migrate_confirm_improvement_v2_fields(project_dir: Path) -> str | None:
@@ -1439,36 +1443,20 @@ def _migrate_confirm_improvement_v2_fields(project_dir: Path) -> str | None:
     no index set to strip.
 
     This entry exists so ``run_pending_migrations()`` carries a durable marker
-    for the schema version that introduced the v2 vocabulary — without it there
+    for the schema version that introduced the v2 vocabulary: without it there
     is no record on a machine that the charter-digest fields were ever
     registered, and a later subtractive migration has no predecessor to reason
     from.
-
-    Read-only: it imports each class and runs one bounded, project-scoped query
-    per model to prove the keyspace resolves under the new fields. Writes
-    nothing. Returns None on success, error string on unexpected failure.
     """
-    try:
-        import sys
-
-        sys.path.insert(0, str(project_dir))
-        from models import (
-            ImprovementCase,
-            ImprovementCharter,
-            ImprovementInvestigation,
-            ImprovementRelease,
-        )
-
-        for model in (
-            ImprovementCharter,
-            ImprovementCase,
-            ImprovementInvestigation,
-            ImprovementRelease,
-        ):
-            list(model.query.filter(project_key="valor"))[:1]
-        return None
-    except Exception as e:
-        return str(e)
+    return _confirm_models_readable(
+        project_dir,
+        (
+            "ImprovementCharter",
+            "ImprovementCase",
+            "ImprovementInvestigation",
+            "ImprovementRelease",
+        ),
+    )
 
 
 MIGRATIONS: dict[str, tuple[callable, str]] = {

--- a/tests/unit/test_agentsession_index_guard_generalized.py
+++ b/tests/unit/test_agentsession_index_guard_generalized.py
@@ -453,16 +453,29 @@ def test_improvement_models_are_enumerated_by_the_runtime_derivation():
     """All eight improvement records expose IndexedFields the same way AgentSession does."""
     from popoto import IndexedField
 
+    from models import ImprovementCase
+
     models_seen = _improvement_models()
     assert len(models_seen) == 8, [m.__name__ for m in models_seen]
 
+    # Every improvement record carries at least one lifecycle index, and never
+    # more than two by default. More than that is a modeling smell, not a
+    # performance one: it means the record is tracking several orthogonal
+    # lifecycles and should be two records. An entry below is a named, reasoned
+    # exemption; a second one costs a second line a reviewer sees.
+    default_maximum = 2
+    index_maximums = {
+        # `state` is lifecycle, `priority` is urgency, `priority_area` is
+        # charter §3 classification; the goals partial reads all three.
+        ImprovementCase: 3,
+    }
+
     for model in models_seen:
         indexed = {name for name, f in model._meta.fields.items() if isinstance(f, IndexedField)}
-        # Every improvement record carries at least one lifecycle index, and
-        # never more than two. More than that is a modeling smell, not a
-        # performance one: it means the record is tracking several orthogonal
-        # lifecycles and should be two records.
-        assert 1 <= len(indexed) <= 2, f"{model.__name__} indexes {indexed}"
+        maximum = index_maximums.get(model, default_maximum)
+        assert 1 <= len(indexed) <= maximum, (
+            f"{model.__name__} indexes {indexed} against a maximum of {maximum}"
+        )
 
 
 def test_improvement_model_indexes_are_low_cardinality():

--- a/tests/unit/test_improvement_charter.py
+++ b/tests/unit/test_improvement_charter.py
@@ -1,0 +1,207 @@
+"""Tests for the charter seed loader (#3255, lane 2b).
+
+``docs/improvement-charter.md`` is the north star and Tom is its only author.
+``ImprovementCharter.load_from_file`` projects that file into an immutable,
+digest-addressed row. These tests hold the four properties the projection has
+to have: it is idempotent per digest, it is append-only, it refuses a file Tom
+does not own, and it resolves the same charter regardless of the caller's cwd.
+
+Uses the autouse ``redis_test_db`` fixture (tests/conftest.py), which claims a
+per-worker test DB — production Redis is never touched. Rows are written under
+a test-scoped ``project_key``, except the one case that must call
+``load_from_file()`` with no arguments at all to exercise the module-anchored
+default; that row lands under the default ``valor`` key inside the claimed test
+DB, which is not the production partition.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from models.improvement_charter import _CHARTER_PATH, ImprovementCharter
+from tools.sdlc_verdict import compute_plan_hash
+
+PK = "test-3255-charter"
+
+
+@pytest.fixture
+def charter_bytes() -> bytes:
+    """The real charter's bytes, so fixtures stay faithful to what ships."""
+    return _CHARTER_PATH.read_bytes()
+
+
+@pytest.fixture
+def charter_copy(tmp_path, charter_bytes):
+    """An LF copy of the real charter in a temporary directory."""
+    path = tmp_path / "improvement-charter.md"
+    path.write_bytes(charter_bytes.replace(b"\r\n", b"\n"))
+    return path
+
+
+def _rows(project_key: str = PK) -> list:
+    return list(ImprovementCharter.query.filter(project_key=project_key))
+
+
+def _snapshot(row) -> dict:
+    """Every stored field of a row, so a later comparison is exhaustive."""
+    return {name: getattr(row, name, None) for name in ImprovementCharter._meta.fields}
+
+
+def _refetch(row_id, project_key: str = PK):
+    for row in _rows(project_key):
+        if getattr(row, "id", None) == row_id:
+            return row
+    return None
+
+
+class TestIdempotentSeed:
+    def test_loading_twice_creates_exactly_one_row(self, charter_copy):
+        first = ImprovementCharter.load_from_file(charter_copy, project_key=PK)
+        second = ImprovementCharter.load_from_file(charter_copy, project_key=PK)
+
+        assert first is not None
+        assert second is not None
+        assert second.id == first.id
+        assert len(_rows()) == 1
+
+    def test_the_row_carries_the_digest_version_and_effective_date(self, charter_copy):
+        row = ImprovementCharter.load_from_file(charter_copy, project_key=PK)
+
+        assert row.digest == compute_plan_hash(charter_copy)
+        assert row.version == 2
+        assert row.effective == "2026-09-07"
+        assert row.state == "active"
+        assert "north star" in row.text.lower()
+
+    def test_a_crlf_copy_digests_identically_to_an_lf_copy(self, tmp_path, charter_copy):
+        crlf = tmp_path / "charter-crlf.md"
+        crlf.write_bytes(charter_copy.read_bytes().replace(b"\n", b"\r\n"))
+
+        lf_row = ImprovementCharter.load_from_file(charter_copy, project_key=PK)
+        crlf_row = ImprovementCharter.load_from_file(crlf, project_key=PK)
+
+        assert crlf_row is not None
+        assert crlf_row.id == lf_row.id
+        assert len(_rows()) == 1
+
+
+class TestAppendOnly:
+    def test_a_changed_byte_appends_and_leaves_the_first_untouched(self, tmp_path, charter_copy):
+        first = ImprovementCharter.load_from_file(charter_copy, project_key=PK)
+        # Snapshot what is persisted, not the in-memory instance: a ContentField
+        # holds plaintext on the row that was just assigned and a store
+        # reference on every row read back, so comparing the two shapes would
+        # fail on representation rather than on mutation.
+        before = _snapshot(_refetch(first.id))
+
+        amended = tmp_path / "charter-amended.md"
+        amended.write_bytes(charter_copy.read_bytes() + b"\nOne amended byte.\n")
+        second = ImprovementCharter.load_from_file(amended, project_key=PK)
+
+        assert second is not None
+        assert second.id != first.id
+        assert second.digest != first.digest
+        assert len(_rows()) == 2
+
+        after = _snapshot(_refetch(first.id))
+        assert after == before, "the loader mutated an existing charter row"
+
+    def test_a_seeded_row_persists_its_text_to_the_content_store(self, charter_copy):
+        """The charter text survives the round trip, not just the digest.
+
+        popoto hydrates a queried row lazily, so a ``ContentField`` reads back
+        as its ``$CF:`` store reference rather than as content — the same shape
+        ``ImprovementExperiment.manifest`` has. Resolving the reference through
+        the store is what proves the text was really written.
+        """
+        seeded = ImprovementCharter.load_from_file(charter_copy, project_key=PK)
+
+        reference = _refetch(seeded.id).text
+        assert reference.startswith("$CF:")
+        stored = ImprovementCharter._meta.fields["text"].store.load(reference)
+        assert stored.decode("utf-8") == charter_copy.read_text()
+
+    def test_the_earlier_row_keeps_its_active_state(self, tmp_path, charter_copy):
+        first = ImprovementCharter.load_from_file(charter_copy, project_key=PK)
+        amended = tmp_path / "charter-amended.md"
+        amended.write_bytes(charter_copy.read_bytes() + b"\nAnother amendment.\n")
+        ImprovementCharter.load_from_file(amended, project_key=PK)
+
+        assert _refetch(first.id).state == "active", "the loader superseded a prior row"
+
+
+class TestRefusal:
+    @pytest.mark.parametrize(
+        "owner_line",
+        ["owner: Someone Else", "owner:", ""],
+        ids=["wrong-owner", "empty-owner", "no-owner-key"],
+    )
+    def test_a_file_tom_does_not_own_is_refused(self, tmp_path, charter_bytes, owner_line):
+        text = charter_bytes.decode().replace("owner: Tom Counsell", owner_line, 1)
+        path = tmp_path / "foreign-charter.md"
+        path.write_text(text)
+
+        assert ImprovementCharter.load_from_file(path, project_key=PK) is None
+        assert _rows() == []
+
+    def test_a_missing_file_returns_none_and_writes_nothing(self, tmp_path):
+        assert ImprovementCharter.load_from_file(tmp_path / "absent.md", project_key=PK) is None
+        assert _rows() == []
+
+    def test_malformed_yaml_returns_none_and_writes_nothing(self, tmp_path):
+        path = tmp_path / "malformed.md"
+        path.write_text("---\nowner: Tom Counsell\nversion: [unclosed\n---\n\n# body\n")
+
+        assert ImprovementCharter.load_from_file(path, project_key=PK) is None
+        assert _rows() == []
+
+    def test_absent_frontmatter_returns_none_and_writes_nothing(self, tmp_path):
+        path = tmp_path / "no-frontmatter.md"
+        path.write_text("# Valor recursive self-improvement charter\n\nowner: Tom Counsell\n")
+
+        assert ImprovementCharter.load_from_file(path, project_key=PK) is None
+        assert _rows() == []
+
+
+class TestTolerantFields:
+    @pytest.mark.parametrize("version_line", ["version: not-a-number", ""], ids=["bad", "absent"])
+    def test_a_malformed_version_does_not_refuse_the_seed(
+        self, tmp_path, charter_bytes, version_line
+    ):
+        """The digest is the identity; a version number is a display detail."""
+        text = charter_bytes.decode().replace("version: 2", version_line, 1)
+        path = tmp_path / "odd-version.md"
+        path.write_text(text)
+
+        row = ImprovementCharter.load_from_file(path, project_key=PK)
+
+        assert row is not None
+        assert row.digest == compute_plan_hash(path)
+        assert len(_rows()) == 1
+
+
+class TestPinned:
+    def test_pinned_returns_the_newest_row(self, tmp_path, charter_copy):
+        ImprovementCharter.load_from_file(charter_copy, project_key=PK)
+        amended = tmp_path / "charter-amended.md"
+        amended.write_bytes(charter_copy.read_bytes() + b"\nLater amendment.\n")
+        newest = ImprovementCharter.load_from_file(amended, project_key=PK)
+
+        pinned = ImprovementCharter.pinned(project_key=PK)
+
+        assert pinned is not None
+        assert pinned.id == newest.id
+
+    def test_pinned_is_none_when_nothing_is_seeded(self):
+        assert ImprovementCharter.pinned(project_key=PK) is None
+
+
+class TestModuleAnchoredDefault:
+    def test_a_no_argument_call_resolves_the_repo_charter_from_any_cwd(self, tmp_path, monkeypatch):
+        """A cwd-relative default would seed a different file, or none, per caller."""
+        monkeypatch.chdir(tmp_path)
+
+        row = ImprovementCharter.load_from_file()
+
+        assert row is not None
+        assert row.digest == compute_plan_hash(_CHARTER_PATH)

--- a/tests/unit/test_improvement_charter.py
+++ b/tests/unit/test_improvement_charter.py
@@ -205,3 +205,31 @@ class TestModuleAnchoredDefault:
 
         assert row is not None
         assert row.digest == compute_plan_hash(_CHARTER_PATH)
+
+
+class TestNoImportCycle:
+    def test_the_sdlc_tools_import_cleanly_in_a_fresh_interpreter(self):
+        """`models.improvement_charter` must not close an import cycle.
+
+        ``tools.sdlc_verdict`` reaches ``agent.sdlc_router``, which imports
+        ``agent/__init__``, which imports ``models/__init__``. A module-level
+        ``compute_plan_hash`` import here therefore breaks any process that
+        imports the SDLC tools before ``models`` — which every ``sdlc-tool``
+        entry point does. A subprocess is the only honest check: this test
+        process has already imported ``models``, so the cycle cannot reproduce
+        in it.
+        """
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2]
+        result = subprocess.run(
+            [sys.executable, "-c", "import tools.sdlc_meta_set"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        assert result.returncode == 0, result.stderr[-2000:]

--- a/tests/unit/test_improvement_charter.py
+++ b/tests/unit/test_improvement_charter.py
@@ -7,7 +7,7 @@ to have: it is idempotent per digest, it is append-only, it refuses a file Tom
 does not own, and it resolves the same charter regardless of the caller's cwd.
 
 Uses the autouse ``redis_test_db`` fixture (tests/conftest.py), which claims a
-per-worker test DB — production Redis is never touched. Rows are written under
+per-worker test DB, production Redis is never touched. Rows are written under
 a test-scoped ``project_key``, except the one case that must call
 ``load_from_file()`` with no arguments at all to exercise the module-anchored
 default; that row lands under the default ``valor`` key inside the claimed test
@@ -110,8 +110,8 @@ class TestAppendOnly:
         """The charter text survives the round trip, not just the digest.
 
         popoto hydrates a queried row lazily, so a ``ContentField`` reads back
-        as its ``$CF:`` store reference rather than as content — the same shape
-        ``ImprovementExperiment.manifest`` has. Resolving the reference through
+        as its ``$CF:`` store reference rather than as content (the same shape
+        ``ImprovementExperiment.manifest`` has). Resolving the reference through
         the store is what proves the text was really written.
         """
         seeded = ImprovementCharter.load_from_file(charter_copy, project_key=PK)
@@ -214,7 +214,7 @@ class TestNoImportCycle:
         ``tools.sdlc_verdict`` reaches ``agent.sdlc_router``, which imports
         ``agent/__init__``, which imports ``models/__init__``. A module-level
         ``compute_plan_hash`` import here therefore breaks any process that
-        imports the SDLC tools before ``models`` — which every ``sdlc-tool``
+        imports the SDLC tools before ``models``, which every ``sdlc-tool``
         entry point does. A subprocess is the only honest check: this test
         process has already imported ``models``, so the cycle cannot reproduce
         in it.

--- a/tests/unit/test_improvement_eligibility.py
+++ b/tests/unit/test_improvement_eligibility.py
@@ -3,7 +3,7 @@
 Charter §7 draws one line: any provider may see open-source work, and client
 work stays on the subscriptions. ``is_open_source`` is the guard on that line,
 so its failure paths are the product rather than an edge case. Every one of
-them is tested separately — a single blanket "error returns False" case would
+them is tested separately: a single blanket "error returns False" case would
 let a typo in the JSON key pass as a caught timeout.
 
 Returning True by mistake is how private client context reaches a foreign
@@ -136,6 +136,18 @@ class TestRepositoryIsPassedPositionally:
         assert "acme/private-app" in run.call_args[0][0]
 
 
+#: The four shapes `tools/improvement_eligibility.py` treats as indeterminate
+#: rather than a determinate "private": a timeout, a non-zero exit (the most
+#: common real-world outage: a `gh` auth failure), empty stdout, and stdout
+#: that fails to parse as JSON. None of them may pin False for the cache TTL.
+INDETERMINATE_OUTCOMES = [
+    pytest.param({"side_effect": subprocess.TimeoutExpired(cmd="gh", timeout=10)}, id="timeout"),
+    pytest.param({"return_value": _completed("", returncode=1)}, id="non-zero-exit"),
+    pytest.param({"return_value": _completed("")}, id="empty-stdout"),
+    pytest.param({"return_value": _completed("not json")}, id="unparseable-json"),
+]
+
+
 class TestCache:
     def test_a_second_call_issues_no_subprocess(self):
         with _gh(return_value=_completed(json.dumps({"visibility": "PUBLIC"}))) as run:
@@ -165,11 +177,18 @@ class TestCache:
             assert is_open_source("open-thing") is True
             assert is_open_source("client-thing") is False
 
-    def test_an_indeterminate_failure_is_not_cached(self):
-        """A transient `gh` outage must not pin False for the whole TTL."""
-        with _gh(side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=10)):
+    @pytest.mark.parametrize("outcome", INDETERMINATE_OUTCOMES)
+    def test_an_indeterminate_failure_is_not_cached(self, outcome):
+        """A transient `gh` outage must not pin False for the whole TTL.
+
+        Each of the four indeterminate shapes must be followed by a fresh
+        subprocess call, not a cached False. Caching False on the non-zero-exit
+        branch specifically is the outage shape a `gh` auth failure produces,
+        and it is the one the mutation check in the review bit on.
+        """
+        with _gh(**outcome):
             assert is_open_source("open-thing") is False
 
         with _gh(return_value=_completed(json.dumps({"visibility": "PUBLIC"}))) as run:
             assert is_open_source("open-thing") is True
-        assert run.call_count == 1
+        assert run.call_count == 1, "the indeterminate outcome must not have been cached"

--- a/tests/unit/test_improvement_eligibility.py
+++ b/tests/unit/test_improvement_eligibility.py
@@ -1,0 +1,175 @@
+"""Tests for the open-source eligibility guard (#3255, lane 2b).
+
+Charter §7 draws one line: any provider may see open-source work, and client
+work stays on the subscriptions. ``is_open_source`` is the guard on that line,
+so its failure paths are the product rather than an edge case. Every one of
+them is tested separately — a single blanket "error returns False" case would
+let a typo in the JSON key pass as a caught timeout.
+
+Returning True by mistake is how private client context reaches a foreign
+provider. Returning False by mistake costs an experiment. The tests are shaped
+around that asymmetry.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from tools import improvement_eligibility
+from tools.improvement_eligibility import _clear_cache, is_open_source
+
+CONFIG = {
+    "projects": {
+        "open-thing": {"github": {"org": "tomcounsell", "repo": "ai"}},
+        "client-thing": {"github": {"org": "acme", "repo": "private-app"}},
+        "no-github": {"name": "a project with no github block"},
+        "no-repo": {"github": {"org": "tomcounsell"}},
+        "no-org": {"github": {"repo": "ai"}},
+    }
+}
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    _clear_cache()
+    yield
+    _clear_cache()
+
+
+@pytest.fixture(autouse=True)
+def config():
+    with patch.object(improvement_eligibility, "load_config", return_value=CONFIG):
+        yield
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _gh(**kwargs):
+    """Patch the subprocess the guard shells out with."""
+    return patch.object(improvement_eligibility.subprocess, "run", **kwargs)
+
+
+class TestDeterminateAnswers:
+    def test_a_public_repository_is_open_source(self):
+        with _gh(return_value=_completed(json.dumps({"visibility": "PUBLIC"}))):
+            assert is_open_source("open-thing") is True
+
+    def test_a_private_repository_is_not(self):
+        with _gh(return_value=_completed(json.dumps({"visibility": "PRIVATE"}))):
+            assert is_open_source("client-thing") is False
+
+    def test_an_internal_repository_is_not(self):
+        with _gh(return_value=_completed(json.dumps({"visibility": "INTERNAL"}))):
+            assert is_open_source("client-thing") is False
+
+    def test_the_comparison_tolerates_case_and_whitespace(self):
+        """`gh` answers uppercase today; the guard must not depend on that."""
+        with _gh(return_value=_completed(json.dumps({"visibility": " public "}))):
+            assert is_open_source("open-thing") is True
+
+
+class TestConfigurationFailsClosed:
+    @pytest.mark.parametrize(
+        "project_key",
+        ["", "unknown-project", "no-github", "no-repo", "no-org"],
+        ids=["empty", "unknown", "no-github-block", "missing-repo", "missing-org"],
+    )
+    def test_an_unresolvable_project_is_not_open_source(self, project_key):
+        with _gh(return_value=_completed(json.dumps({"visibility": "PUBLIC"}))) as run:
+            assert is_open_source(project_key) is False
+        assert run.call_count == 0, "an unresolvable project must not reach the network"
+
+
+class TestSubprocessFailsClosed:
+    def test_a_non_zero_exit_is_not_open_source(self):
+        with _gh(return_value=_completed("", returncode=1)):
+            assert is_open_source("open-thing") is False
+
+    def test_a_timeout_is_not_open_source(self):
+        with _gh(side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=10)):
+            assert is_open_source("open-thing") is False
+
+    def test_a_missing_gh_binary_is_not_open_source(self):
+        with _gh(side_effect=FileNotFoundError("gh")):
+            assert is_open_source("open-thing") is False
+
+    def test_unparseable_json_is_not_open_source(self):
+        with _gh(return_value=_completed("not json at all")):
+            assert is_open_source("open-thing") is False
+
+    def test_empty_output_is_not_open_source(self):
+        with _gh(return_value=_completed("")):
+            assert is_open_source("open-thing") is False
+
+    def test_an_absent_visibility_key_is_not_open_source(self):
+        with _gh(return_value=_completed(json.dumps({"name": "ai"}))):
+            assert is_open_source("open-thing") is False
+
+
+class TestRepositoryIsPassedPositionally:
+    """`GH_REPO` is set process-wide and `gh` reads it before cwd.
+
+    A bare `gh repo view --json visibility` would answer about whatever
+    `GH_REPO` names, exit 0, and look healthy. The correct and incorrect
+    versions differ by one argument, so only a test can tell them apart.
+    """
+
+    def test_the_argv_carries_the_resolved_repository(self):
+        with _gh(return_value=_completed(json.dumps({"visibility": "PRIVATE"}))) as run:
+            is_open_source("client-thing")
+
+        argv = run.call_args[0][0]
+        assert "acme/private-app" in argv
+
+    def test_a_decoy_gh_repo_does_not_make_a_private_project_open_source(self, monkeypatch):
+        monkeypatch.setenv("GH_REPO", "tomcounsell/ai")
+
+        with _gh(return_value=_completed(json.dumps({"visibility": "PRIVATE"}))) as run:
+            assert is_open_source("client-thing") is False
+
+        assert "acme/private-app" in run.call_args[0][0]
+
+
+class TestCache:
+    def test_a_second_call_issues_no_subprocess(self):
+        with _gh(return_value=_completed(json.dumps({"visibility": "PUBLIC"}))) as run:
+            assert is_open_source("open-thing") is True
+            assert is_open_source("open-thing") is True
+
+        assert run.call_count == 1
+
+    def test_an_expired_entry_is_re_resolved(self):
+        with _gh(return_value=_completed(json.dumps({"visibility": "PUBLIC"}))) as run:
+            assert is_open_source("open-thing", ttl_seconds=0) is True
+            assert is_open_source("open-thing", ttl_seconds=0) is True
+
+        assert run.call_count == 2
+
+    def test_the_cache_does_not_confuse_two_projects(self):
+        answers = {
+            "tomcounsell/ai": json.dumps({"visibility": "PUBLIC"}),
+            "acme/private-app": json.dumps({"visibility": "PRIVATE"}),
+        }
+
+        def fake_run(argv, **kwargs):
+            repo = next(a for a in argv if "/" in a)
+            return _completed(answers[repo])
+
+        with _gh(side_effect=fake_run):
+            assert is_open_source("open-thing") is True
+            assert is_open_source("client-thing") is False
+
+    def test_an_indeterminate_failure_is_not_cached(self):
+        """A transient `gh` outage must not pin False for the whole TTL."""
+        with _gh(side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=10)):
+            assert is_open_source("open-thing") is False
+
+        with _gh(return_value=_completed(json.dumps({"visibility": "PUBLIC"}))) as run:
+            assert is_open_source("open-thing") is True
+        assert run.call_count == 1

--- a/tests/unit/test_improvement_eligibility.py
+++ b/tests/unit/test_improvement_eligibility.py
@@ -182,9 +182,10 @@ class TestCache:
         """A transient `gh` outage must not pin False for the whole TTL.
 
         Each of the four indeterminate shapes must be followed by a fresh
-        subprocess call, not a cached False. Caching False on the non-zero-exit
-        branch specifically is the outage shape a `gh` auth failure produces,
-        and it is the one the mutation check in the review bit on.
+        subprocess call, not a cached False. Only a determinate answer is
+        cacheable: a `gh` auth failure surfaces as a non-zero exit, so caching
+        False there would keep an open-source project reading as private long
+        after the outage cleared.
         """
         with _gh(**outcome):
             assert is_open_source("open-thing") is False

--- a/tests/unit/test_improvement_models.py
+++ b/tests/unit/test_improvement_models.py
@@ -31,7 +31,7 @@ from models import (
     ImprovementModelRevision,
     ImprovementRelease,
 )
-from models.improvement_case import CASE_PRIORITIES, CASE_STATES
+from models.improvement_case import CASE_PRIORITIES, CASE_STATES, PRIORITY_AREAS
 from models.improvement_charter import CHARTER_STATES
 from models.improvement_evaluation import EVALUATION_STATES, EVALUATION_VERDICTS
 from models.improvement_evidence import EVIDENCE_CLASSIFICATIONS, EVIDENCE_KINDS
@@ -52,7 +52,11 @@ INDEXED_VOCABULARIES: dict[type, dict[str, tuple[str, ...]]] = {
         "classification": EVIDENCE_CLASSIFICATIONS,
     },
     ImprovementModelRevision: {"state": MODEL_REVISION_STATES},
-    ImprovementCase: {"state": CASE_STATES, "priority": CASE_PRIORITIES},
+    ImprovementCase: {
+        "state": CASE_STATES,
+        "priority": CASE_PRIORITIES,
+        "priority_area": PRIORITY_AREAS,
+    },
     ImprovementInvestigation: {
         "kind": INVESTIGATION_KINDS,
         "state": INVESTIGATION_STATES,
@@ -84,6 +88,16 @@ IMMORTAL_MODELS = (
     ImprovementEvaluation,
     ImprovementRelease,
 )
+
+#: How many values a declared vocabulary may hold, per field. The default is
+#: the general rule; an entry here is a named, reasoned exemption, and adding a
+#: second one costs a second line a reviewer sees.
+DEFAULT_VOCABULARY_MAXIMUM = 8
+VOCABULARY_MAXIMUMS: dict[tuple[type, str], int] = {
+    # charter §3 vocabulary; eleven index sets per project partition,
+    # membership reads only.
+    (ImprovementCase, "priority_area"): 11,
+}
 
 #: Cardinality tripwire: field names that must never carry an index, whatever
 #: model they appear on. These are the shapes the schema gate exists to stop.
@@ -157,9 +171,12 @@ class TestIndexCardinalityGate:
     @pytest.mark.parametrize("model", ALL_MODELS, ids=lambda m: m.__name__)
     def test_declared_vocabularies_are_small(self, model):
         for name, vocabulary in INDEXED_VOCABULARIES[model].items():
-            assert 2 <= len(vocabulary) <= 8, (
-                f"{model.__name__}.{name} has {len(vocabulary)} values; an index set "
-                "per value stops being cheap well before this."
+            maximum = VOCABULARY_MAXIMUMS.get((model, name), DEFAULT_VOCABULARY_MAXIMUM)
+            assert 2 <= len(vocabulary) <= maximum, (
+                f"{model.__name__}.{name} has {len(vocabulary)} values against a maximum "
+                f"of {maximum}; an index set per value stops being cheap well before "
+                "this. A larger vocabulary needs a named entry in VOCABULARY_MAXIMUMS "
+                "carrying its reason."
             )
             assert len(set(vocabulary)) == len(vocabulary), "duplicate value in vocabulary"
 

--- a/tests/unit/test_improvement_resources.py
+++ b/tests/unit/test_improvement_resources.py
@@ -1,0 +1,193 @@
+"""Tests for the charter §8 resource probe (#3255, lane 2b).
+
+Charter §8 names the resources the loop may use and then says the quiet part:
+"These are expected capabilities, not a claim that every credential or
+integration currently works. Verify availability before relying on it." The
+probe is that verification, and it has two obligations that pull against each
+other — report enough to be useful, and never emit a credential.
+
+Two properties carry most of the weight here. ``unknown`` is the honest default
+on any uncertainty, because reporting ``absent`` for a resource that exists
+sends the next lane out to acquire something already sitting in the vault. And
+a credential that reaches the probe must never leave it: this repo runs
+``op run --no-masking`` by design, so op's own masking is not a backstop and
+the probe's output discipline is the only guard.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+
+import pytest
+
+from tools.improvement_resources import RESOURCES, STATES, probe
+
+FAKE_CREDENTIAL = "cf-tok-ZZQQ-distinctive-sentinel-9174"
+
+VAULT_LISTING = """[
+  {"id": "a1", "title": "Google Workspace (personal)", "vault": {"name": "m-valor"}},
+  {"id": "a2", "title": "Google Workspace work account", "vault": {"name": "m-valor"}},
+  {"id": "a3", "title": "Virtual debit card", "vault": {"name": "m-valor"}},
+  {"id": "a4", "title": "Cloudflare API token", "vault": {"name": "m-valor"}}
+]"""
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["op"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def make_runner(*, listing=VAULT_LISTING, listing_rc=0, credential=FAKE_CREDENTIAL, wrangler=True):
+    """A runner that answers each argv shape the probe issues."""
+
+    def runner(argv):
+        if argv[0] == "op" and "list" in argv:
+            return _completed(listing, listing_rc)
+        if argv[0] == "op" and "read" in argv:
+            return _completed(credential)
+        if argv[0] == "wrangler":
+            if not wrangler:
+                raise FileNotFoundError("wrangler")
+            return _completed("wrangler 3.0.0")
+        return _completed("", 1)
+
+    return runner
+
+
+def _strings(value) -> list[str]:
+    """Every string anywhere in a nested structure, at any depth."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        return [s for v in value.values() for s in _strings(v)] + [
+            s for k in value for s in _strings(k)
+        ]
+    if isinstance(value, list | tuple):
+        return [s for v in value for s in _strings(v)]
+    return []
+
+
+class TestShape:
+    def test_every_named_resource_is_classified(self):
+        report = probe(runner=make_runner())
+
+        assert set(report) == set(RESOURCES)
+        for name, entry in report.items():
+            assert entry["state"] in STATES, f"{name} reported {entry['state']!r}"
+            assert entry["detail"], f"{name} reported no detail"
+            assert set(entry) == {"state", "detail", "fingerprint"}
+
+    def test_a_present_vault_item_is_verified(self):
+        report = probe(runner=make_runner())
+
+        assert report["workspace_personal"]["state"] == "verified"
+        assert report["cloudflare_account"]["state"] == "verified"
+
+    def test_a_missing_title_is_absent_when_the_listing_was_readable(self):
+        report = probe(runner=make_runner(listing='[{"id": "a1", "title": "unrelated"}]'))
+
+        assert report["virtual_debit_card"]["state"] == "absent"
+
+
+class TestNeverLeaks:
+    def test_a_seeded_credential_appears_nowhere_in_the_report(self):
+        report = probe(runner=make_runner())
+
+        assert FAKE_CREDENTIAL not in str(report)
+        assert all(FAKE_CREDENTIAL not in s for s in _strings(report))
+
+    def test_no_prefix_of_the_credential_is_emitted_either(self):
+        report = probe(runner=make_runner())
+
+        prefix = FAKE_CREDENTIAL[:8]
+        assert all(prefix not in s for s in _strings(report))
+
+    def test_the_credential_is_reported_as_a_sha256_fingerprint(self):
+        report = probe(runner=make_runner())
+
+        expected = "sha256:" + hashlib.sha256(FAKE_CREDENTIAL.encode()).hexdigest()
+        assert report["cloudflare_account"]["fingerprint"] == expected
+
+    def test_resources_that_read_no_credential_carry_no_fingerprint(self):
+        report = probe(runner=make_runner())
+
+        assert report["workspace_personal"]["fingerprint"] is None
+
+
+class TestUnknownIsTheHonestDefault:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"listing_rc": 1},
+            {"listing": ""},
+            {"listing": "not json"},
+            {"listing": '{"unexpected": "shape"}'},
+        ],
+        ids=["non-zero-exit", "empty", "unparseable", "unexpected-shape"],
+    )
+    def test_an_unusable_listing_is_unknown_never_absent(self, kwargs):
+        """Exit 0 alone proves nothing, and `absent` sends a lane shopping."""
+        report = probe(runner=make_runner(**kwargs))
+
+        for name in ("workspace_personal", "workspace_work", "virtual_debit_card"):
+            assert report[name]["state"] == "unknown", name
+
+    def test_a_runner_that_raises_yields_unknown_rather_than_an_exception(self):
+        def exploding(argv):
+            raise RuntimeError("op is not authenticated")
+
+        report = probe(runner=exploding)
+
+        assert set(report) == set(RESOURCES)
+        assert report["workspace_personal"]["state"] == "unknown"
+
+    def test_a_timeout_is_unknown(self):
+        def timing_out(argv):
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=15)
+
+        assert probe(runner=timing_out)["cloudflare_account"]["state"] == "unknown"
+
+
+class TestOneFailureDoesNotBlankTheRest:
+    def test_a_dead_vault_still_leaves_the_cli_classified(self):
+        report = probe(runner=make_runner(listing_rc=1))
+
+        assert report["workspace_personal"]["state"] == "unknown"
+        assert report["cloudflare_cli"]["state"] == "verified"
+
+    def test_a_missing_wrangler_does_not_disturb_the_vault_answers(self):
+        report = probe(runner=make_runner(wrangler=False))
+
+        assert report["cloudflare_cli"]["state"] == "absent"
+        assert report["workspace_personal"]["state"] == "verified"
+
+    def test_a_failed_fingerprint_leaves_the_account_verified(self):
+        """Presence and fingerprint are separate claims; losing one keeps the other."""
+        report = probe(runner=make_runner(credential=""))
+
+        assert report["cloudflare_account"]["state"] == "verified"
+        assert report["cloudflare_account"]["fingerprint"] is None
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize(
+        "runner",
+        [
+            lambda argv: (_ for _ in ()).throw(RuntimeError("boom")),
+            lambda argv: _completed("", 127),
+            lambda argv: None,
+        ],
+        ids=["raises", "exit-127", "returns-none"],
+    )
+    def test_probe_returns_a_full_report_whatever_the_runner_does(self, runner):
+        report = probe(runner=runner)
+
+        assert set(report) == set(RESOURCES)
+
+    def test_the_default_runner_is_used_when_none_is_given(self):
+        """No injection: it shells out for real and still returns a full report."""
+        report = probe()
+
+        assert set(report) == set(RESOURCES)
+        for entry in report.values():
+            assert entry["state"] in STATES

--- a/tests/unit/test_improvement_resources.py
+++ b/tests/unit/test_improvement_resources.py
@@ -200,12 +200,12 @@ class TestNeverRaises:
         assert set(report) == set(RESOURCES)
 
     def test_the_default_runner_shells_out_and_captures_output(self):
-        """Exercise ``_default_runner`` directly with a harmless argv, not the real
+        """``_default_runner`` shells out and captures stdout, proven on a harmless argv.
 
-        ``op``/``wrangler`` binaries. ``probe()`` with no injection would shell out
-        for real and wait the full 15s timeout on a machine without a service
-        account token; that belongs in a manual verification row, not the unit
-        suite.
+        The argv is a throwaway interpreter, never the real ``op``/``wrangler``
+        binaries. ``probe()`` with no injection would shell out for real and wait
+        the full 15s timeout on a machine without a service account token; that
+        belongs in a manual verification row, not the unit suite.
         """
         result = _default_runner([sys.executable, "-c", "print('probe-ok')"])
 

--- a/tests/unit/test_improvement_resources.py
+++ b/tests/unit/test_improvement_resources.py
@@ -4,7 +4,7 @@ Charter §8 names the resources the loop may use and then says the quiet part:
 "These are expected capabilities, not a claim that every credential or
 integration currently works. Verify availability before relying on it." The
 probe is that verification, and it has two obligations that pull against each
-other — report enough to be useful, and never emit a credential.
+other: report enough to be useful, and never emit a credential.
 
 Two properties carry most of the weight here. ``unknown`` is the honest default
 on any uncertainty, because reporting ``absent`` for a resource that exists
@@ -18,10 +18,11 @@ from __future__ import annotations
 
 import hashlib
 import subprocess
+import sys
 
 import pytest
 
-from tools.improvement_resources import RESOURCES, STATES, probe
+from tools.improvement_resources import RESOURCES, STATES, _default_runner, probe
 
 FAKE_CREDENTIAL = "cf-tok-ZZQQ-distinctive-sentinel-9174"
 
@@ -198,10 +199,16 @@ class TestNeverRaises:
 
         assert set(report) == set(RESOURCES)
 
-    def test_the_default_runner_is_used_when_none_is_given(self):
-        """No injection: it shells out for real and still returns a full report."""
-        report = probe()
+    def test_the_default_runner_shells_out_and_captures_output(self):
+        """Exercise ``_default_runner`` directly with a harmless argv, not the real
 
-        assert set(report) == set(RESOURCES)
-        for entry in report.values():
-            assert entry["state"] in STATES
+        ``op``/``wrangler`` binaries. ``probe()`` with no injection would shell out
+        for real and wait the full 15s timeout on a machine without a service
+        account token; that belongs in a manual verification row, not the unit
+        suite.
+        """
+        result = _default_runner([sys.executable, "-c", "print('probe-ok')"])
+
+        assert isinstance(result, subprocess.CompletedProcess)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "probe-ok"

--- a/tests/unit/test_improvement_resources.py
+++ b/tests/unit/test_improvement_resources.py
@@ -147,6 +147,20 @@ class TestUnknownIsTheHonestDefault:
 
         assert probe(runner=timing_out)["cloudflare_account"]["state"] == "unknown"
 
+    def test_a_wrangler_timeout_is_unknown_not_absent(self):
+        """The wrangler leg's mirror of the vault leg's timeout test.
+
+        A timeout is uncertainty, not evidence the binary is missing. Only
+        `FileNotFoundError` earns `absent`; this must not collapse to it.
+        """
+
+        def timing_out(argv):
+            if argv[0] == "wrangler":
+                raise subprocess.TimeoutExpired(cmd=argv, timeout=15)
+            return _completed(VAULT_LISTING)
+
+        assert probe(runner=timing_out)["cloudflare_cli"]["state"] == "unknown"
+
 
 class TestOneFailureDoesNotBlankTheRest:
     def test_a_dead_vault_still_leaves_the_cli_classified(self):

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -10,7 +10,7 @@ every call site that migrated to `settings.timeouts.<field>` changes too.
 import pytest
 from pydantic import ValidationError
 
-from config.settings import Settings, TimeoutSettings
+from config.settings import ImprovementSettings, Settings, TimeoutSettings
 
 
 class TestTimeoutSettingsDefaults:
@@ -128,3 +128,45 @@ class TestTimeoutSettingsEnvOverride:
 
         with pytest.raises(ValidationError):
             Settings()
+
+
+class TestImprovementSettingsBudgetUnits:
+    """The three budget units charter v2 reserves separately (#3255).
+
+    Two are dollars on different windows, and the third is not money at all
+    (Claude concurrency). The window boundaries are typed rather than free
+    strings so a bad override fails at settings load rather than at the first
+    window computation.
+    """
+
+    def test_budget_defaults(self):
+        s = ImprovementSettings()
+
+        assert s.daily_paid_inference_usd == 10.00
+        assert s.weekly_infrastructure_usd == 50.00
+        assert s.budget_day_boundary == "UTC"
+        assert s.budget_week_start == "monday"
+
+    def test_concurrency_is_still_the_third_unit(self):
+        assert ImprovementSettings().max_concurrent_research_sessions == 1
+
+    @pytest.mark.parametrize(
+        "withdrawn",
+        ["daily_external_llm_usd", "portfolio_allocation", "daily_question_ceiling"],
+    )
+    def test_withdrawn_vocabulary_is_absent(self, withdrawn):
+        """Charter v2 replaced all three; a leftover would be read as current."""
+        assert withdrawn not in ImprovementSettings.model_fields
+
+    @pytest.mark.parametrize(
+        "field,bad_value",
+        [
+            ("budget_day_boundary", "PST"),
+            ("budget_week_start", "Monday"),
+            ("daily_paid_inference_usd", -1.0),
+            ("weekly_infrastructure_usd", -1.0),
+        ],
+    )
+    def test_invalid_values_fail_at_load(self, field, bad_value):
+        with pytest.raises(ValidationError):
+            ImprovementSettings(**{field: bad_value})

--- a/tests/unit/test_ui_app.py
+++ b/tests/unit/test_ui_app.py
@@ -787,6 +787,36 @@ class TestImprovementPartials:
         assert "The charter record could not be read" in resp.text
         assert "No charter seeded" not in resp.text
 
+    def test_goals_partial_lists_open_cases_and_omits_terminal_ones(self, client):
+        """Open is every state but released and rejected, and paused is open.
+
+        Reads through the ``state`` index one open state at a time, so this also
+        pins that the indexed lookup returns what the partition scan used to.
+        """
+        from datetime import UTC, datetime
+
+        from models.improvement_case import ImprovementCase
+
+        pk = "test-3255-case-states"
+        now = datetime.now(UTC)
+        seeded = [
+            ImprovementCase.create(
+                project_key=pk, state=state, title=f"case-{state}", created_at=now
+            )
+            for state in ("observed", "paused", "released", "rejected")
+        ]
+        try:
+            resp = client.get(f"/_partials/improvement/goals/?project_key={pk}")
+
+            assert resp.status_code == 200
+            assert "case-observed" in resp.text
+            assert "case-paused" in resp.text
+            assert "case-released" not in resp.text
+            assert "case-rejected" not in resp.text
+        finally:
+            for row in seeded:
+                row.delete()
+
     def test_goals_partial_reports_unavailable_when_the_case_read_raises(self, client, monkeypatch):
         """A broken case query must not read as an honest zero."""
         from models.improvement_case import ImprovementCase
@@ -805,13 +835,18 @@ class TestImprovementPartials:
     def test_goals_partial_reports_unavailable_when_the_assumption_read_raises(
         self, client, monkeypatch
     ):
-        """A broken assumption query must not read as an honest zero."""
-        import ui.data.improvement as improvement_data
+        """A broken assumption query must not read as an honest zero.
+
+        Patches the real dependency, not ``get_provisional_assumptions``: the
+        classification only means something if the failure it classifies is the
+        one production can actually hit.
+        """
+        from models.improvement_investigation import ImprovementInvestigation
 
         def _raise(*args, **kwargs):
-            raise RuntimeError("assumption read failed")
+            raise RuntimeError("investigation store unreachable")
 
-        monkeypatch.setattr(improvement_data, "get_provisional_assumptions", _raise)
+        monkeypatch.setattr(ImprovementInvestigation.query, "filter", _raise)
 
         resp = client.get("/_partials/improvement/goals/?project_key=test-3255-empty")
 

--- a/tests/unit/test_ui_app.py
+++ b/tests/unit/test_ui_app.py
@@ -769,3 +769,52 @@ class TestImprovementPartials:
         assert resp.status_code == 200
         assert seeded.digest in resp.text
         assert "No charter seeded" not in resp.text
+
+    def test_goals_partial_reports_unavailable_when_the_charter_read_raises(
+        self, client, monkeypatch
+    ):
+        """A broken charter query must not read as an honest zero."""
+        from models.improvement_charter import ImprovementCharter
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("charter store unreachable")
+
+        monkeypatch.setattr(ImprovementCharter, "pinned", classmethod(_raise))
+
+        resp = client.get("/_partials/improvement/goals/?project_key=test-3255-empty")
+
+        assert resp.status_code == 200
+        assert "The charter record could not be read" in resp.text
+        assert "No charter seeded" not in resp.text
+
+    def test_goals_partial_reports_unavailable_when_the_case_read_raises(self, client, monkeypatch):
+        """A broken case query must not read as an honest zero."""
+        from models.improvement_case import ImprovementCase
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("case store unreachable")
+
+        monkeypatch.setattr(ImprovementCase.query, "filter", _raise)
+
+        resp = client.get("/_partials/improvement/goals/?project_key=test-3255-empty")
+
+        assert resp.status_code == 200
+        assert "Case records unavailable" in resp.text
+        assert "No cases opened yet" not in resp.text
+
+    def test_goals_partial_reports_unavailable_when_the_assumption_read_raises(
+        self, client, monkeypatch
+    ):
+        """A broken assumption query must not read as an honest zero."""
+        import ui.data.improvement as improvement_data
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("assumption read failed")
+
+        monkeypatch.setattr(improvement_data, "get_provisional_assumptions", _raise)
+
+        resp = client.get("/_partials/improvement/goals/?project_key=test-3255-empty")
+
+        assert resp.status_code == 200
+        assert "Assumptions unavailable" in resp.text
+        assert "Nothing proceeding on an unresolved assumption" not in resp.text

--- a/tests/unit/test_ui_app.py
+++ b/tests/unit/test_ui_app.py
@@ -723,14 +723,49 @@ class TestImprovementPartials:
         import ui.data.improvement as improvement_data
 
         exported = [n for n in dir(improvement_data) if n.startswith("get_")]
+        # Stays an exact list on purpose: it is what stops a later lane from
+        # quietly adding an activity counter beside the honest panels.
         assert exported == [
             "get_coverage",
+            "get_goals",
             "get_intervention_burden",
             "get_provisional_assumptions",
         ]
 
-    def test_index_page_links_both_improvement_partials(self, client):
+    def test_index_page_links_all_improvement_partials(self, client):
         resp = client.get("/")
         assert resp.status_code == 200
+        assert "/_partials/improvement/goals/" in resp.text
         assert "/_partials/improvement/coverage/" in resp.text
         assert "/_partials/improvement/burden/" in resp.text
+
+    def test_goals_partial_renders_on_an_empty_namespace(self, client):
+        """An unseeded project says so, and names no zero."""
+        resp = client.get("/_partials/improvement/goals/?project_key=test-3255-empty")
+
+        assert resp.status_code == 200
+        assert "No charter seeded" in resp.text
+        assert "improvement-goals" in resp.text
+
+    def test_goals_partial_attributes_every_empty_section_to_a_lane(self, client):
+        resp = client.get("/_partials/improvement/goals/?project_key=test-3255-empty")
+
+        assert resp.status_code == 200
+        for heading in ("Acquired abilities", "Evaluations", "Rejected approaches"):
+            assert heading in resp.text
+        assert "Nothing yet;" in resp.text
+
+    def test_goals_partial_renders_a_seeded_charter_with_its_full_digest(self, client, tmp_path):
+        """The digest renders in full: comparing it by eye is the point."""
+        from models.improvement_charter import _CHARTER_PATH, ImprovementCharter
+
+        pk = "test-3255-goals"
+        copy = tmp_path / "charter.md"
+        copy.write_bytes(_CHARTER_PATH.read_bytes())
+        seeded = ImprovementCharter.load_from_file(copy, project_key=pk)
+
+        resp = client.get(f"/_partials/improvement/goals/?project_key={pk}")
+
+        assert resp.status_code == 200
+        assert seeded.digest in resp.text
+        assert "No charter seeded" not in resp.text

--- a/tools/improvement_eligibility.py
+++ b/tools/improvement_eligibility.py
@@ -106,7 +106,9 @@ def is_open_source(project_key: str, *, ttl_seconds: int = DEFAULT_TTL_SECONDS) 
             text=True,
             timeout=10,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+    except (subprocess.TimeoutExpired, OSError) as e:
+        # OSError covers a missing `gh` binary (FileNotFoundError is one of its
+        # subclasses), so it does not need naming separately.
         logger.warning("improvement eligibility: gh failed for %s: %s", repository, e)
         return False
 

--- a/tools/improvement_eligibility.py
+++ b/tools/improvement_eligibility.py
@@ -1,0 +1,129 @@
+"""Charter §7: which projects may be routed to any provider.
+
+Charter §7 draws one line. Work on an open-source codebase carries no model or
+provider restriction. Regular client work, and the private context that comes
+with it, stays on the Claude and Codex subscriptions.
+
+``is_open_source`` is the guard on that line, and it **fails closed to client**
+on every uncertainty. The asymmetry is the whole design: returning True by
+mistake routes private client context to a foreign provider, while returning
+False by mistake costs one experiment. A missing project, a missing ``github``
+block, a missing ``org`` or ``repo``, a non-zero ``gh`` exit, a timeout, an
+absent binary, unparseable JSON, and an absent ``visibility`` key all return
+False, and each is tested separately.
+
+**The repository is passed positionally.** ``GH_REPO`` is set process-wide by
+``agent/sdk_client.py`` and ``gh`` reads it before cwd, so a bare
+``gh repo view --json visibility`` would answer about whatever ``GH_REPO``
+names, exit 0, and look entirely healthy. The positional argument overrides the
+environment. The correct and the incorrect version differ by one argument, so
+only a test tells them apart.
+
+**The cache is process-local, not Redis.** A repository's visibility changes on
+a scale of months, and a durable cache would cost either a Popoto model (with
+its migration, schema-gate entry, and TTL decision) or a key in the improvement
+control namespace, which does not exist yet and is not this module's to create.
+A module-level dict with a monotonic expiry is the cheapest correct thing, and
+a later lane can promote it if cross-process sharing is ever shown to matter.
+
+Only determinate answers are cached. A ``gh`` outage returns False for that
+call without pinning False for the rest of the window, so a transient failure
+costs one experiment rather than fifteen minutes of them.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+
+from bridge.routing import load_config
+
+logger = logging.getLogger(__name__)
+
+#: How long a determinate answer stays good, in seconds.
+DEFAULT_TTL_SECONDS = 900
+
+#: The one visibility value that means "any provider may see this".
+_PUBLIC = "PUBLIC"
+
+#: project_key -> (answer, monotonic expiry). Process-local by design.
+_CACHE: dict[str, tuple[bool, float]] = {}
+
+
+def _clear_cache() -> None:
+    """Drop every cached answer. For tests and for a forced re-resolve."""
+    _CACHE.clear()
+
+
+def _resolve_repository(project_key: str) -> str | None:
+    """``org/repo`` for a project, or None when it cannot be resolved."""
+    try:
+        projects = load_config().get("projects", {})
+    except Exception as e:
+        logger.warning("improvement eligibility: project config unreadable: %s", e)
+        return None
+
+    project = projects.get(project_key)
+    if not isinstance(project, dict):
+        return None
+
+    github = project.get("github")
+    if not isinstance(github, dict):
+        return None
+
+    org = github.get("org")
+    repo = github.get("repo")
+    if not org or not repo:
+        return None
+    return f"{org}/{repo}"
+
+
+def is_open_source(project_key: str, *, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> bool:
+    """True only when this project's repository is provably public.
+
+    Every other outcome is False, including every failure. See the module
+    docstring for why the asymmetry is deliberate and why the repository is
+    passed to ``gh`` positionally.
+    """
+    cached = _CACHE.get(project_key)
+    if cached is not None and cached[1] > time.monotonic():
+        return cached[0]
+
+    repository = _resolve_repository(project_key)
+    if repository is None:
+        logger.debug(
+            "improvement eligibility: %r has no resolvable repository; treating as client",
+            project_key,
+        )
+        return False
+
+    try:
+        completed = subprocess.run(
+            ["gh", "repo", "view", repository, "--json", "visibility"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.warning("improvement eligibility: gh failed for %s: %s", repository, e)
+        return False
+
+    if completed.returncode != 0 or not (completed.stdout or "").strip():
+        logger.warning(
+            "improvement eligibility: gh exited %s for %s; treating as client",
+            completed.returncode,
+            repository,
+        )
+        return False
+
+    try:
+        visibility = json.loads(completed.stdout)["visibility"]
+    except (ValueError, TypeError, KeyError) as e:
+        logger.warning("improvement eligibility: gh output unusable for %s: %s", repository, e)
+        return False
+
+    answer = str(visibility).strip().upper() == _PUBLIC
+    _CACHE[project_key] = (answer, time.monotonic() + ttl_seconds)
+    return answer

--- a/tools/improvement_resources.py
+++ b/tools/improvement_resources.py
@@ -1,0 +1,215 @@
+"""Charter §8: verify each named resource before relying on it.
+
+Charter §8 lists what the loop may use — a browser, personal and work Google
+Workspace accounts, a virtual debit card, a funded Cloudflare account and its
+connected CLI — and then says the part that matters here: "These are expected
+capabilities, not a claim that every credential or integration currently works.
+Verify availability before relying on it." ``probe`` is that verification.
+
+Three states, and the default is the honest one:
+
+- ``verified`` — the resource was found.
+- ``absent`` — a successful, parseable listing did not contain it.
+- ``unknown`` — anything else at all.
+
+``unknown`` is written on every uncertainty, never ``absent``. Reporting a
+resource absent when it exists sends the next lane out to acquire something
+already sitting in the vault, and older ``op`` builds could exit 0 on
+unrecognized server errors, so a zero exit code proves nothing by itself.
+
+**A credential never leaves this module.** The presence leg reads
+``op item list --format json``, which returns titles, ids, vaults, and
+timestamps and never a field value, so most of this module cannot leak by
+construction. Where a fingerprint is wanted the credential is read, hashed
+immediately, and reported as ``sha256:<hex>``; the plaintext is never returned,
+never logged, and never placed in an argv. This repo runs ``op run
+--no-masking`` by design, so op's own masking is not available as a backstop
+and this discipline is the only guard. ``runner`` is injectable so a test can
+seed a distinctive fake credential and assert it appears nowhere in the result.
+
+**Nothing here raises.** A probe that throws inside a controller tick is worse
+than one that reports ``unknown``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: The vault of record for this machine's service account.
+VAULT = "m-valor"
+
+#: The three states a resource may be reported in.
+STATES: tuple[str, ...] = ("verified", "absent", "unknown")
+
+#: Every resource charter §8 names, in report order.
+RESOURCES: tuple[str, ...] = (
+    "workspace_personal",
+    "workspace_work",
+    "virtual_debit_card",
+    "cloudflare_account",
+    "cloudflare_cli",
+    "vault_write",
+)
+
+#: Vault-backed resources, and the title keyword sets that identify each. A
+#: title matches when every keyword in any one set appears in it, compared
+#: case-insensitively. Heuristic by necessity: the probe classifies whatever
+#: titles the vault happens to carry, and a near-miss reports absent rather
+#: than inventing a match.
+_VAULT_TITLE_KEYWORDS: dict[str, tuple[tuple[str, ...], ...]] = {
+    "workspace_personal": (("google", "personal"), ("workspace", "personal")),
+    "workspace_work": (("google", "work"), ("workspace", "work")),
+    "virtual_debit_card": (("virtual", "card"), ("debit", "card")),
+    "cloudflare_account": (("cloudflare",),),
+}
+
+#: The sanctioned vault writer. It belongs to the lane that builds the
+#: acquisition path, so its absence here is a correct answer, not a defect.
+_VAULT_WRITER = Path(__file__).resolve().parent / "vault_write.py"
+
+Runner = Callable[[list[str]], "subprocess.CompletedProcess"]
+
+
+def _default_runner(argv: list[str]) -> subprocess.CompletedProcess:
+    """Shell out with a bound timeout, capturing output rather than printing it."""
+    return subprocess.run(argv, capture_output=True, text=True, timeout=15)
+
+
+def _entry(state: str, detail: str, fingerprint: str | None = None) -> dict:
+    return {"state": state, "detail": detail, "fingerprint": fingerprint}
+
+
+def _run(runner: Runner, argv: list[str]) -> subprocess.CompletedProcess | None:
+    """Run a command, returning None on any failure at all."""
+    try:
+        completed = runner(argv)
+    except Exception as e:
+        logger.debug("resource probe: %s failed: %s", argv[0], e)
+        return None
+    if not isinstance(completed, subprocess.CompletedProcess):
+        return None
+    return completed
+
+
+def _vault_titles(runner: Runner) -> list[str] | None:
+    """Titles in the vault, or None when the listing could not be trusted.
+
+    None is the ``unknown`` signal. It covers a failed call, a non-zero exit,
+    empty output, unparseable JSON, and a parseable payload that is not the
+    list of objects this command is documented to return.
+    """
+    completed = _run(runner, ["op", "item", "list", "--vault", VAULT, "--format", "json"])
+    if completed is None or completed.returncode != 0:
+        return None
+
+    stdout = (completed.stdout or "").strip()
+    if not stdout:
+        return None
+
+    try:
+        payload = json.loads(stdout)
+    except ValueError:
+        return None
+    if not isinstance(payload, list):
+        return None
+
+    return [str(item.get("title", "")) for item in payload if isinstance(item, dict)]
+
+
+def _matches(title: str, keyword_sets: tuple[tuple[str, ...], ...]) -> bool:
+    lowered = title.lower()
+    return any(all(word in lowered for word in words) for words in keyword_sets)
+
+
+def _fingerprint_cloudflare_token(runner: Runner, title: str) -> str | None:
+    """``sha256:<hex>`` of the Cloudflare credential, or None.
+
+    The plaintext lives in a local for exactly as long as it takes to hash it.
+    It is never returned, never logged, and never placed in an argv.
+    """
+    completed = _run(runner, ["op", "read", f"op://{VAULT}/{title}/credential"])
+    if completed is None or completed.returncode != 0:
+        return None
+
+    secret = (completed.stdout or "").strip()
+    if not secret:
+        return None
+    return "sha256:" + hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+def _probe_vault_resources(runner: Runner) -> dict[str, dict]:
+    titles = _vault_titles(runner)
+    if titles is None:
+        return {
+            name: _entry(
+                "unknown",
+                f"the {VAULT} vault listing could not be read; op may be unauthenticated",
+            )
+            for name in _VAULT_TITLE_KEYWORDS
+        }
+
+    report: dict[str, dict] = {}
+    for name, keyword_sets in _VAULT_TITLE_KEYWORDS.items():
+        matched = next((t for t in titles if _matches(t, keyword_sets)), None)
+        if matched is None:
+            report[name] = _entry("absent", f"no item in {VAULT} matches this resource")
+            continue
+
+        fingerprint = None
+        if name == "cloudflare_account":
+            fingerprint = _fingerprint_cloudflare_token(runner, matched)
+        report[name] = _entry("verified", f"found in {VAULT}", fingerprint)
+    return report
+
+
+def _probe_cloudflare_cli(runner: Runner) -> dict:
+    completed = _run(runner, ["wrangler", "--version"])
+    if completed is None:
+        return _entry("absent", "wrangler is not installed or not on PATH")
+    if completed.returncode != 0:
+        return _entry("unknown", f"wrangler exited {completed.returncode}")
+    return _entry("verified", "wrangler answers on PATH")
+
+
+def _probe_vault_write() -> dict:
+    if _VAULT_WRITER.exists():
+        return _entry("verified", "the sanctioned vault writer is present")
+    return _entry("absent", "no sanctioned vault writer exists yet; acquisition is not wired")
+
+
+def probe(*, runner: Runner | None = None) -> dict[str, dict]:
+    """Classify every charter §8 resource without emitting a credential.
+
+    Returns one entry per name in :data:`RESOURCES`, each
+    ``{"state", "detail", "fingerprint"}``. Never raises: every failure becomes
+    an ``unknown`` on the affected resource, and one dead call does not blank
+    the rest of the report.
+    """
+    runner = runner or _default_runner
+    report: dict[str, dict] = {}
+
+    try:
+        report.update(_probe_vault_resources(runner))
+    except Exception as e:
+        logger.warning("resource probe: vault leg failed: %s", e)
+
+    try:
+        report["cloudflare_cli"] = _probe_cloudflare_cli(runner)
+    except Exception as e:
+        logger.warning("resource probe: wrangler leg failed: %s", e)
+
+    try:
+        report["vault_write"] = _probe_vault_write()
+    except Exception as e:
+        logger.warning("resource probe: vault-writer leg failed: %s", e)
+
+    for name in RESOURCES:
+        report.setdefault(name, _entry("unknown", "the probe could not run this check"))
+    return {name: report[name] for name in RESOURCES}

--- a/tools/improvement_resources.py
+++ b/tools/improvement_resources.py
@@ -1,16 +1,16 @@
 """Charter §8: verify each named resource before relying on it.
 
-Charter §8 lists what the loop may use — a browser, personal and work Google
+Charter §8 lists what the loop may use (a browser, personal and work Google
 Workspace accounts, a virtual debit card, a funded Cloudflare account and its
-connected CLI — and then says the part that matters here: "These are expected
+connected CLI) and then says the part that matters here: "These are expected
 capabilities, not a claim that every credential or integration currently works.
 Verify availability before relying on it." ``probe`` is that verification.
 
 Three states, and the default is the honest one:
 
-- ``verified`` — the resource was found.
-- ``absent`` — a successful, parseable listing did not contain it.
-- ``unknown`` — anything else at all.
+- ``verified``: the resource was found.
+- ``absent``: a successful, parseable listing did not contain it.
+- ``unknown``: anything else at all.
 
 ``unknown`` is written on every uncertainty, never ``absent``. Reporting a
 resource absent when it exists sends the next lane out to acquire something
@@ -177,7 +177,7 @@ def _probe_cloudflare_cli(runner: Runner) -> dict:
     one distinction that matters here: ``FileNotFoundError`` means the binary
     genuinely is not on PATH (``absent``), while a timeout, an ``OSError``, or
     any other failure means the check was inconclusive (``unknown``). Reusing
-    ``_run`` would make a `wrangler` timeout report `absent` — a certain
+    ``_run`` would make a `wrangler` timeout report `absent`: a certain
     answer to an uncertain question, and the specific harm the three-state
     vocabulary exists to prevent.
     """

--- a/tools/improvement_resources.py
+++ b/tools/improvement_resources.py
@@ -170,9 +170,26 @@ def _probe_vault_resources(runner: Runner) -> dict[str, dict]:
 
 
 def _probe_cloudflare_cli(runner: Runner) -> dict:
-    completed = _run(runner, ["wrangler", "--version"])
-    if completed is None:
+    """Classify the wrangler CLI, distinguishing "not installed" from "uncertain".
+
+    Calls the runner directly rather than through :func:`_run`, because
+    ``_run`` collapses every exception into a single ``None`` and loses the
+    one distinction that matters here: ``FileNotFoundError`` means the binary
+    genuinely is not on PATH (``absent``), while a timeout, an ``OSError``, or
+    any other failure means the check was inconclusive (``unknown``). Reusing
+    ``_run`` would make a `wrangler` timeout report `absent` — a certain
+    answer to an uncertain question, and the specific harm the three-state
+    vocabulary exists to prevent.
+    """
+    try:
+        completed = runner(["wrangler", "--version"])
+    except FileNotFoundError:
         return _entry("absent", "wrangler is not installed or not on PATH")
+    except Exception as e:
+        logger.debug("resource probe: wrangler --version failed: %s", e)
+        return _entry("unknown", f"wrangler check did not complete: {e}")
+    if not isinstance(completed, subprocess.CompletedProcess):
+        return _entry("unknown", "wrangler check returned an unexpected result")
     if completed.returncode != 0:
         return _entry("unknown", f"wrangler exited {completed.returncode}")
     return _entry("verified", "wrangler answers on PATH")

--- a/tools/improvement_resources.py
+++ b/tools/improvement_resources.py
@@ -22,8 +22,8 @@ unrecognized server errors, so a zero exit code proves nothing by itself.
 timestamps and never a field value, so most of this module cannot leak by
 construction. Where a fingerprint is wanted the credential is read, hashed
 immediately, and reported as ``sha256:<hex>``; the plaintext is never returned,
-never logged, and never placed in an argv. This repo runs ``op run
---no-masking`` by design, so op's own masking is not available as a backstop
+never logged, and never placed in an argv. This repo disables 1Password's own
+output masking by design, so that masking is not available as a backstop here
 and this discipline is the only guard. ``runner`` is injectable so a test can
 seed a distinctive fake credential and assert it appears nowhere in the result.
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -396,6 +396,23 @@ def create_app() -> FastAPI:
             {"coverage": get_coverage(project_key=project_key)},
         )
 
+    @app.get("/_partials/improvement/goals/", response_class=HTMLResponse)
+    def partial_improvement_goals(request: Request, project_key: str = "valor"):
+        """HTMX partial: the charter §11 readable record (#3255).
+
+        Which charter the work is ranked under, the §3 priorities, the open
+        cases and why each ranks where it does, and an explicit note for every
+        heading no lane writes yet. Empty sections name the lane that fills
+        them rather than showing a zero.
+        """
+        from ui.data.improvement import get_goals
+
+        return templates.TemplateResponse(
+            request,
+            "improvement/goals.html",
+            {"goals": get_goals(project_key=project_key)},
+        )
+
     @app.get("/_partials/improvement/burden/", response_class=HTMLResponse)
     def partial_improvement_burden(request: Request, project_key: str = "valor"):
         """HTMX partial: how often a human had to step in, and of what kind (#3177)."""

--- a/ui/app.py
+++ b/ui/app.py
@@ -418,12 +418,22 @@ def create_app() -> FastAPI:
         """HTMX partial: how often a human had to step in, and of what kind (#3177)."""
         from ui.data.improvement import get_intervention_burden, get_provisional_assumptions
 
+        # The assumption read propagates its failures so the goals partial can
+        # tell "none" apart from "unreadable". This panel has no unavailable
+        # rendering, so it degrades to hiding the section rather than taking the
+        # whole burden panel down with it.
+        try:
+            assumptions = get_provisional_assumptions(project_key=project_key)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("improvement burden partial: assumption read failed: %s", exc)
+            assumptions = []
+
         return templates.TemplateResponse(
             request,
             "improvement/intervention_burden.html",
             {
                 "burden": get_intervention_burden(project_key=project_key),
-                "assumptions": get_provisional_assumptions(project_key=project_key),
+                "assumptions": assumptions,
             },
         )
 

--- a/ui/data/improvement.py
+++ b/ui/data/improvement.py
@@ -168,14 +168,17 @@ def get_provisional_assumptions(
     a recorded assumption rather than a question in someone's queue. Surfacing
     them is the whole compensating control: an assumption nobody can see is
     indistinguishable from a fact.
+
+    A failed read propagates. Returning ``[]`` here would hand every caller an
+    empty list that is indistinguishable from an honest zero, which is the one
+    thing this list exists to prevent; the caller classifies the failure.
+
+    Raises:
+        Exception: whatever the investigation read raises.
     """
     from models.improvement_investigation import ImprovementInvestigation
 
-    try:
-        rows = list(ImprovementInvestigation.query.filter(project_key=project_key))
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("improvement dashboard: investigation read failed: %s", exc)
-        return []
+    rows = list(ImprovementInvestigation.query.filter(project_key=project_key))
 
     cutoff = datetime.now(UTC) - timedelta(days=window_days)
     out = []
@@ -250,10 +253,20 @@ def get_goals(project_key: str = "valor") -> dict:
     cases = []
     cases_unavailable = False
     try:
-        from models.improvement_case import ImprovementCase
+        from models.improvement_case import OPEN_CASE_STATES, ImprovementCase
 
-        rows = list(ImprovementCase.query.filter(project_key=project_key))
-        open_rows = [r for r in rows if getattr(r, "state", None) not in ("released", "rejected")]
+        # One indexed lookup per open state, which is what the ``state``
+        # IndexedField is declared for. Cases are immortal, so hydrating the
+        # whole partition and filtering in Python would grow without bound on a
+        # partial that polls every 60 seconds. The open-state vocabulary is the
+        # model's, never restated here.
+        open_rows = []
+        for state in OPEN_CASE_STATES:
+            open_rows.extend(ImprovementCase.query.filter(project_key=project_key, state=state))
+        open_rows.sort(
+            key=lambda r: getattr(r, "created_at", None) or datetime.min.replace(tzinfo=UTC),
+            reverse=True,
+        )
         for row in open_rows:
             cases.append(
                 {
@@ -269,9 +282,9 @@ def get_goals(project_key: str = "valor") -> dict:
         logger.warning("improvement dashboard: case read failed: %s", exc)
         cases_unavailable = True
 
+    assumptions_unavailable = False
     try:
         assumptions = get_provisional_assumptions(project_key=project_key)
-        assumptions_unavailable = False
     except Exception as exc:  # noqa: BLE001
         logger.warning("improvement dashboard: assumption read failed: %s", exc)
         assumptions = []

--- a/ui/data/improvement.py
+++ b/ui/data/improvement.py
@@ -198,7 +198,7 @@ def get_provisional_assumptions(
 
 
 #: Charter §3's early priorities, in the charter's own order. Strong starting
-#: hypotheses, explicitly "not a fixed allocation or permanent ordering" — the
+#: hypotheses, explicitly "not a fixed allocation or permanent ordering": the
 #: partial says so, because a list rendered without that sentence reads as a
 #: quota.
 CHARTER_PRIORITIES = (

--- a/ui/data/improvement.py
+++ b/ui/data/improvement.py
@@ -195,3 +195,101 @@ def get_provisional_assumptions(
         )
     out.sort(key=lambda d: d["created_at"] or datetime.min.replace(tzinfo=UTC), reverse=True)
     return out
+
+
+#: Charter §3's early priorities, in the charter's own order. Strong starting
+#: hypotheses, explicitly "not a fixed allocation or permanent ordering" — the
+#: partial says so, because a list rendered without that sentence reads as a
+#: quota.
+CHARTER_PRIORITIES = (
+    "Discover free or inexpensive inference and integrate suitable models",
+    "Improve token efficiency without losing needed context or reasoning",
+    "Expand and improve the skill library",
+    "Design narrow subagent personas for niche tasks",
+    "Acquire cloud execution capacity for continuous operation",
+)
+
+#: The charter §11 headings this build cannot fill yet, and the lane that will.
+#: Each renders as "nothing yet, written by lane N" rather than as a zero: a
+#: zero claims a measurement was taken.
+PENDING_SECTIONS = (
+    ("Acquired abilities", "lane 3 records these as it acquires them"),
+    ("Evaluations", "lane 4 writes the paired blinded evaluations"),
+    ("Rejected approaches", "lane 5 records what was tried and set aside"),
+    ("Resource use by budget unit", "lane 3 meters paid inference and infrastructure"),
+)
+
+
+def get_goals(project_key: str = "valor") -> dict:
+    """The charter §11 readable record: goals, ranking, and what is not measured.
+
+    Three distinguishable states per section, never two. Content, "nothing yet,
+    written by lane N", and "unavailable" when the underlying read raised.
+    Collapsing the last two would let a broken query read as an honest zero,
+    which is the specific dishonesty the charter warns against.
+    """
+    charter = None
+    charter_unavailable = False
+    try:
+        from models.improvement_charter import ImprovementCharter
+
+        pinned = ImprovementCharter.pinned(project_key=project_key)
+        if pinned is not None:
+            charter = {
+                "version": getattr(pinned, "version", None),
+                "effective": getattr(pinned, "effective", None),
+                # Full digest, never truncated: comparing it against the file
+                # by eye is the point of showing it at all.
+                "digest": getattr(pinned, "digest", None),
+                "created_at": getattr(pinned, "created_at", None),
+            }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("improvement dashboard: charter read failed: %s", exc)
+        charter_unavailable = True
+
+    cases = []
+    cases_unavailable = False
+    try:
+        from models.improvement_case import ImprovementCase
+
+        rows = list(ImprovementCase.query.filter(project_key=project_key))
+        open_rows = [r for r in rows if getattr(r, "state", None) not in ("released", "rejected")]
+        for row in open_rows:
+            cases.append(
+                {
+                    "title": getattr(row, "title", None),
+                    "state": getattr(row, "state", None),
+                    "priority": getattr(row, "priority", None),
+                    "priority_area": getattr(row, "priority_area", None),
+                    "ranking_rationale": getattr(row, "ranking_rationale", None),
+                    "charter_digest": getattr(row, "charter_digest", None),
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("improvement dashboard: case read failed: %s", exc)
+        cases_unavailable = True
+
+    try:
+        assumptions = get_provisional_assumptions(project_key=project_key)
+        assumptions_unavailable = False
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("improvement dashboard: assumption read failed: %s", exc)
+        assumptions = []
+        assumptions_unavailable = True
+
+    return {
+        "project_key": project_key,
+        "charter": charter,
+        "charter_unavailable": charter_unavailable,
+        "charter_missing": charter is None and not charter_unavailable,
+        "priorities": list(CHARTER_PRIORITIES),
+        "cases": cases,
+        "cases_unavailable": cases_unavailable,
+        "no_cases_yet": not cases and not cases_unavailable,
+        "assumptions": assumptions,
+        "assumptions_unavailable": assumptions_unavailable,
+        "pending_sections": [
+            {"heading": heading, "written_by": written_by}
+            for heading, written_by in PENDING_SECTIONS
+        ],
+    }

--- a/ui/templates/improvement/goals.html
+++ b/ui/templates/improvement/goals.html
@@ -5,8 +5,8 @@
    rejected approaches, unresolved assumptions, and resource use.
 
    Most of that has no writer yet. Every heading below therefore renders one of
-   three distinguishable states — content, "nothing yet, written by lane N", or
-   "unavailable" when the read failed — and never a bare zero. A zero claims a
+   three distinguishable states (content, "nothing yet, written by lane N", or
+   "unavailable" when the read failed) and never a bare zero. A zero claims a
    measurement was taken, and the charter is explicit that an absence of
    detection is not a result.
 #}

--- a/ui/templates/improvement/goals.html
+++ b/ui/templates/improvement/goals.html
@@ -30,18 +30,18 @@
     <p class="improvement-meta"><code>{{ goals.charter.digest }}</code></p>
     {% endif %}
 
-    <h3>Early priorities</h3>
+    <h4>Early priorities</h4>
     <p class="improvement-meta">
         Charter §3 starting hypotheses, not a fixed allocation or a permanent
         ordering. The ranking changes as evidence changes.
     </p>
-    <ol class="improvement-priorities">
+    <ol class="improvement-list">
         {% for priority in goals.priorities %}
         <li>{{ priority }}</li>
         {% endfor %}
     </ol>
 
-    <h3>Open cases</h3>
+    <h4>Open cases</h4>
     {% if goals.cases_unavailable %}
     <p class="improvement-warning">Case records unavailable; the read failed.</p>
     {% elif goals.no_cases_yet %}
@@ -50,7 +50,7 @@
         charter digest above.
     </p>
     {% else %}
-    <table class="improvement-cases">
+    <table class="improvement-table">
         <thead>
             <tr>
                 <th>Case</th>
@@ -72,7 +72,7 @@
     </table>
     {% endif %}
 
-    <h3>Unresolved assumptions</h3>
+    <h4>Unresolved assumptions</h4>
     {% if goals.assumptions_unavailable %}
     <p class="improvement-warning">Assumptions unavailable; the read failed.</p>
     {% elif not goals.assumptions %}
@@ -80,7 +80,7 @@
         Nothing proceeding on an unresolved assumption right now.
     </p>
     {% else %}
-    <ul class="improvement-assumptions">
+    <ul class="improvement-list">
         {% for assumption in goals.assumptions %}
         <li>{{ assumption.assumption }}</li>
         {% endfor %}
@@ -88,7 +88,7 @@
     {% endif %}
 
     {% for section in goals.pending_sections %}
-    <h3>{{ section.heading }}</h3>
+    <h4>{{ section.heading }}</h4>
     <p class="improvement-meta">Nothing yet; {{ section.written_by }}.</p>
     {% endfor %}
 </div>

--- a/ui/templates/improvement/goals.html
+++ b/ui/templates/improvement/goals.html
@@ -1,0 +1,94 @@
+{# Improvement: goals and their relationship to the charter (#3255).
+
+   Charter §11 asks for a readable record of current goals, their relationship
+   to the charter, opportunity ranking, acquired abilities, evaluations,
+   rejected approaches, unresolved assumptions, and resource use.
+
+   Most of that has no writer yet. Every heading below therefore renders one of
+   three distinguishable states — content, "nothing yet, written by lane N", or
+   "unavailable" when the read failed — and never a bare zero. A zero claims a
+   measurement was taken, and the charter is explicit that an absence of
+   detection is not a result.
+#}
+<div class="improvement-panel" id="improvement-goals">
+    {% if goals.charter_unavailable %}
+    <p class="improvement-warning">
+        The charter record could not be read. This panel cannot say which
+        charter the work below was ranked under.
+    </p>
+    {% elif goals.charter_missing %}
+    <p class="improvement-warning">
+        No charter seeded for <code>{{ goals.project_key }}</code>. Nothing has
+        pinned <code>docs/improvement-charter.md</code> into a record yet, so no
+        case can cite the version it was ranked under.
+    </p>
+    {% else %}
+    <p class="improvement-meta">
+        Charter version {{ goals.charter.version }},
+        effective {{ goals.charter.effective or 'undated' }}.
+    </p>
+    <p class="improvement-meta"><code>{{ goals.charter.digest }}</code></p>
+    {% endif %}
+
+    <h3>Early priorities</h3>
+    <p class="improvement-meta">
+        Charter §3 starting hypotheses, not a fixed allocation or a permanent
+        ordering. The ranking changes as evidence changes.
+    </p>
+    <ol class="improvement-priorities">
+        {% for priority in goals.priorities %}
+        <li>{{ priority }}</li>
+        {% endfor %}
+    </ol>
+
+    <h3>Open cases</h3>
+    {% if goals.cases_unavailable %}
+    <p class="improvement-warning">Case records unavailable; the read failed.</p>
+    {% elif goals.no_cases_yet %}
+    <p class="improvement-meta">
+        No cases opened yet. Lane 3 opens the first one, ranked under the
+        charter digest above.
+    </p>
+    {% else %}
+    <table class="improvement-cases">
+        <thead>
+            <tr>
+                <th>Case</th>
+                <th>Area</th>
+                <th>State</th>
+                <th>Why it ranks here</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for case in goals.cases %}
+            <tr>
+                <td>{{ case.title or 'untitled' }}</td>
+                <td>{{ (case.priority_area or 'other') | replace('_', ' ') }}</td>
+                <td>{{ case.state }}</td>
+                <td>{{ case.ranking_rationale or 'no rationale recorded' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+
+    <h3>Unresolved assumptions</h3>
+    {% if goals.assumptions_unavailable %}
+    <p class="improvement-warning">Assumptions unavailable; the read failed.</p>
+    {% elif not goals.assumptions %}
+    <p class="improvement-meta">
+        Nothing proceeding on an unresolved assumption right now.
+    </p>
+    {% else %}
+    <ul class="improvement-assumptions">
+        {% for assumption in goals.assumptions %}
+        <li>{{ assumption.assumption }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    {% for section in goals.pending_sections %}
+    <h3>{{ section.heading }}</h3>
+    <p class="improvement-meta">Nothing yet; {{ section.written_by }}.</p>
+    {% endfor %}
+</div>

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -86,6 +86,9 @@ function toggleStats() {
             never achievements: nothing here reports experiment count or merged-patch
             count, because activity is not improvement.
         </p>
+        <div id="improvement-goals-panel"
+             hx-get="/_partials/improvement/goals/" hx-trigger="revealed, every 60s"
+             hx-swap="innerHTML"></div>
         <div id="improvement-coverage-panel"
              hx-get="/_partials/improvement/coverage/" hx-trigger="revealed, every 60s"
              hx-swap="innerHTML"></div>


### PR DESCRIPTION
## Summary
Lane 2b of the recursive self-improvement controller (#3177): the delta between what PR #3224 shipped from the pre-charter plan and what `docs/improvement-charter.md` v2 requires. Plan: `docs/plans/improvement-controller-lane-2b-charter-v2-delta.md` (critique round 2: READY TO BUILD, no concerns).

## Changes
- `ImprovementCharter` seeds from `docs/improvement-charter.md` by content digest (`load_from_file`, append-only, refuses any owner other than Tom Counsell; `pinned()` lookup). Digest is a plain `Field` because the index guard rejects an `IndexedField` there.
- `ImprovementCase`: `objective` deleted; `priority_area` (charter §3 vocabulary plus `other`), `ranking_rationale`, `charter_digest` added. `ImprovementInvestigation` and `ImprovementRelease` carry `charter_digest`. Schema-gate exemptions recorded; v2 marker migration registered.
- `ImprovementSettings`: `daily_external_llm_usd` renamed `daily_paid_inference_usd`; `weekly_infrastructure_usd=50.00`, `budget_day_boundary="UTC"`, `budget_week_start="monday"` added; `portfolio_allocation` removed; `.env.example` comment updated to name the three budget units.
- `tools/improvement_eligibility.py`: charter §7 guard deriving open-source eligibility from GitHub visibility, positional repo (immune to `GH_REPO`), uppercase compare, process-local TTL cache, fails closed to client on every error.
- `tools/improvement_resources.py`: charter §8 probe reporting verified/absent/unknown per resource by vault title, SHA-256 fingerprint, and harmless reads; never emits a credential; unknown on any uncertainty.
- Dashboard: charter §11 goals partial wired into the index.
- Docs: `docs/features/improvement-controller.md` describes the v2 status quo with a Charter section; capability matrix gains the lane 2b section.
- Fixed an import cycle the charter loader introduced (a fresh-subprocess regression test guards it).
- Follow-through: lane 7 filed as #3274; #3215, #3216, #3217, #3218 refreshed by comment.
- Patch round (review #2): charter loader reads the file once instead of three times; the resource-probe unit test no longer shells out to real `op`/`wrangler`; three new tests cover the goals partial's `unavailable` render branches; the eligibility cache's "not cached" test is parametrized over all four indeterminate `gh` outcomes with a mutation check on the non-zero-exit branch; the denylist doc claim is corrected; a shared `_confirm_models_readable` helper replaces the duplicated marker-migration body; house-style and typing nits addressed.

## Testing
- [x] 397 passed across the eleven plan-named unit files, plus 33 in `tests/unit/test_migrations.py` (`scripts/pytest-clean.sh`)
- [x] All 41 plan Verification rows pass (`agent.verification_parser.run_checks`, 0 malformed, 0 skipped)
- [x] Mutation checks applied and reverted, each red on its intended assertion, including the eligibility cache's non-zero-exit branch added this round
- [x] Lint/format checks passing (`ruff check .`, `ruff format .`)

## Resource probe (this machine, no values)
workspace_personal unknown, workspace_work unknown, virtual_debit_card unknown, cloudflare_account unknown (op had no service-account token in the build shell); cloudflare_cli absent (wrangler not installed); vault_write absent (lane 3's). #3274's first task re-runs the probe under the token.

## Documentation
- [x] Docs created per plan requirements
- [x] Related docs scanned for updates

## Definition of Done
- [x] Built: Code implemented and working
- [x] Tested: All tests passing
- [x] Documented: Docs created/updated
- [x] Quality: Lint and format checks pass

Closes #3255
Refs #3177
