### PR TITLE
Rewrite terminal-flush promise fallback in Valor's voice (#3290)

### DIFF
--- a/agent/notification_copy.py
+++ b/agent/notification_copy.py
@@ -12,6 +12,9 @@ Constants:
     exhausted recovery attempts). Nothing will resume automatically.
   * ``FAILURE_NOTICE`` — the session crashed (running -> failed) from an uncaught
     exception. The error was logged; the request did not complete.
+  * ``TERMINAL_PROMISE_FALLBACK_MESSAGE`` — the promise gate withheld a held final
+    reply at terminal-flush time, and no live agent remained to redraft it. Says
+    only that the message was withheld.
 """
 
 from __future__ import annotations
@@ -23,3 +26,24 @@ INTERRUPT_NO_RESUME = (
 
 # Session crashed (running -> failed) from an uncaught exception.
 FAILURE_NOTICE = "Something went wrong and I couldn't finish that. I've logged the error."
+
+# Promise gate withheld a held final reply at terminal-flush time (#2423). There is
+# no live agent left to self-draft a rewrite, so the flush substitutes rather than
+# suppresses (suppression would reintroduce the #1796 swallowed-reply class).
+#
+# Three constraints on this text. Two are from #3135: it must itself pass the promise
+# heuristic (`bridge.promise_gate._evaluate_promise_heuristic` must return "allow"),
+# and every clause must be true given ONLY "the gate withheld the message" — a block
+# verdict carries no information about whether any work completed, so the text may not
+# claim failure or invent a pending request. The third is from #3290: this reaches the
+# human in Telegram, so it is Valor speaking in the first person and names no internal
+# mechanism. Do not reintroduce the words "filter", "session", or "gate" here.
+#
+# "It wasn't good enough." is deliberately verdict-shaped rather than content-shaped.
+# An earlier draft said "It made a commitment I couldn't back up", which is false for
+# the behavioral-change block class: that class fires on bare acknowledgments
+# ("you're right", "good point", "makes sense") containing no commitment at all.
+TERMINAL_PROMISE_FALLBACK_MESSAGE = (
+    "I didn't send my last message here. It wasn't good enough. "
+    "If you were waiting on something from me, just ask again."
+)

--- a/agent/session_health.py
+++ b/agent/session_health.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 import agent.session_state as _session_state
+from agent.notification_copy import TERMINAL_PROMISE_FALLBACK_MESSAGE
 from agent.session_pickup import _truthy
 from agent.session_runner.liveness import derive_sdk_ever_output, subprocess_hang_verdict
 from agent.session_stall_classifier import (
@@ -2523,21 +2524,6 @@ async def _deliver_terminal_interrupt_notice(entry: "AgentSession") -> None:
         ttl=INTERRUPTED_SENT_DEDUP_TTL_SECONDS,
         message=INTERRUPT_NO_RESUME,
     )
-
-
-# Honest substitution delivered in place of a promise-flagged deferred draft on
-# terminal paths (issue #2423). At terminal-flush time there is no live agent to
-# self-draft a rewrite, so the flush substitutes rather than suppresses (suppression
-# would reintroduce the #1796 swallowed-reply class). Two constraints on this text
-# (#3135): it must itself pass the promise heuristic, and every clause must be true
-# given only "the filter withheld the final message" — a block verdict carries no
-# information about whether any work completed, so the text may not claim failure
-# or invent a pending request.
-TERMINAL_PROMISE_FALLBACK_MESSAGE = (
-    "An outbound safety filter held back this session's final message. "
-    "The work may have finished normally; if something you expected is "
-    "missing, ask again in a new message."
-)
 
 
 def _gate_terminal_promise(message: str, *, transport: str, session_id: str | None) -> str:

--- a/docs/features/pm-final-delivery.md
+++ b/docs/features/pm-final-delivery.md
@@ -158,11 +158,12 @@ real terminal interruption, and zero messages for an auto-resuming one.
 
 ## Reason-Aware Interrupt Messaging and Failure Notification (issue #1877; silent-resume inversion)
 
-`agent/notification_copy.py` is the single source of truth for the
-user-facing lifecycle copy that both this doc and `agent/messenger.py` /
-`agent/session_completion.py` reference: `INTERRUPT_NO_RESUME` and
-`FAILURE_NOTICE`. Send sites import these constants rather than inlining
-literal strings, so a copy change is a single-file edit. There is no longer
+`agent/notification_copy.py` is the single source of truth for **every**
+user-facing session-lifecycle string, including the `INTERRUPT_NO_RESUME` and
+`FAILURE_NOTICE` constants this doc and `agent/messenger.py` /
+`agent/session_completion.py` reference. Read the module for the current set
+rather than relying on a list here. Send sites import these constants rather
+than inlining literal strings, so a copy change is a single-file edit. There is no longer
 a "will resume automatically" copy constant — auto-resuming interruptions
 are silent by design (issue #1937), not narrated with a mid-flight promise.
 A session finishes or fails; nothing in between speaks.

--- a/docs/features/promise-gate.md
+++ b/docs/features/promise-gate.md
@@ -76,14 +76,41 @@ session ends before self-draft steering was consumed. At that moment there is
 no live agent to self-draft a rewrite, so `needs_self_draft=True` is not an
 option. `agent/session_health._gate_terminal_promise` therefore evaluates the
 exact text about to ship and, on a block, **substitutes** the fallback
-`TERMINAL_PROMISE_FALLBACK_MESSAGE` ("An outbound safety filter held back this
-session's final message. The work may have finished normally; if something you
-expected is missing, ask again in a new message."). The wording asserts only
-what the gate can actually know: a filter withheld the message. It claims
-nothing about whether the session's work finished, because a block verdict
-carries no such information (#3135; the substitution design itself is still
-open there). Suppression is not used, because it reintroduces the swallowed-reply
-class. The gate is fail-open for delivery: an evaluation error delivers the
+`TERMINAL_PROMISE_FALLBACK_MESSAGE` ("I didn't send my last message here. It
+wasn't good enough. If you were waiting on something from me, just ask again.").
+The constant is defined in `agent/notification_copy.py`, alongside
+`INTERRUPT_NO_RESUME` and `FAILURE_NOTICE`, under the #1877 contract that every
+user-facing lifecycle string has exactly one definition that send sites import
+by name.
+
+Three constraints bind this text, and a change that breaks any of them is a
+regression:
+
+1. **It must pass the promise heuristic itself** — the substitution may never be
+   a new empty promise (#3135).
+2. **Every clause must be true given only "the gate withheld the message"** — a
+   block verdict carries no information about whether any work completed, so the
+   text may not claim failure or invent a pending request (#3135). Note that it
+   may not characterize the *withheld* text either: the behavioral-change block
+   class fires on bare acknowledgments ("you're right", "good point") that
+   contain no promise, so wording like "it made a commitment I couldn't back up"
+   is false in that case. "It wasn't good enough" is verdict-shaped rather than
+   content-shaped, and holds under both block classes.
+3. **It is Valor speaking, in the first person, naming no internal mechanism**
+   (#3290). This route delivers straight to the human in Telegram, where the
+   standing rule is that no raw error or internal narration ever reaches them.
+   The pre-#3290 wording ("An outbound safety filter held back this session's
+   final message") satisfied constraints 1 and 2 and was still flagged by the
+   principal as off-persona, which is why constraint 3 is enforced by its own
+   test rather than left to review.
+
+`tests/unit/test_deferred_self_draft_completed.py` locks constraints 1 and 3
+(`test_substitute_message_passes_the_heuristic` and
+`test_substitute_message_names_no_internal_mechanism`, the latter matching
+`filter` / `session` / `gate` on word boundaries so `possession` does not
+false-positive).
+
+Suppression is not used, because it reintroduces the swallowed-reply class. The gate is fail-open for delivery: an evaluation error delivers the
 original text rather than swallowing the reply. This route always evaluates
 via the regex heuristic — it never reaches the LLM layer the drafter's main
 path now uses, because there is no agent left to consume an LLM-derived

--- a/docs/features/promise-gate.md
+++ b/docs/features/promise-gate.md
@@ -110,7 +110,8 @@ regression:
 `filter` / `session` / `gate` on word boundaries so `possession` does not
 false-positive).
 
-Suppression is not used, because it reintroduces the swallowed-reply class. The gate is fail-open for delivery: an evaluation error delivers the
+Suppression is not used, because it reintroduces the swallowed-reply class.
+The gate is fail-open for delivery: an evaluation error delivers the
 original text rather than swallowing the reply. This route always evaluates
 via the regex heuristic — it never reaches the LLM layer the drafter's main
 path now uses, because there is no agent left to consume an LLM-derived

--- a/docs/plans/terminal-flush-fallback-persona-voice.md
+++ b/docs/plans/terminal-flush-fallback-persona-voice.md
@@ -209,7 +209,11 @@ assertion alone would not catch it.
    unaffected once its import is repointed).
 5. Update `docs/features/promise-gate.md` Terminal flush section (~line 79) to quote the new
    string and describe the voice constraint alongside the truth constraint.
-6. `grep -rn "outbound safety filter"` returns nothing.
+6. `grep -rn "outbound safety filter"` returns no hit that is **live copy**. Three deliberate
+   mentions remain and are correct: the known-bad anchor in the new test's docstring, the
+   rationale for constraint 3 in `docs/features/promise-gate.md`, and this plan's own problem
+   statement. Naming the exact wording that violated the rule is what stops a future editor
+   reintroducing it; a bare "don't use jargon" comment does not.
 7. `python -m ruff check` and `python -m ruff format`.
 8. Narrow test run: `scripts/pytest-clean.sh tests/unit/test_deferred_self_draft_completed.py`.
 
@@ -256,7 +260,9 @@ New for this issue:
 - A test asserts the text contains none of `filter`, `session`, `gate` (case-insensitive).
 - All pre-existing tests in `tests/unit/test_deferred_self_draft_completed.py` pass, including both
   #3135 tests.
-- `grep -rn "outbound safety filter"` returns no hits.
+- `grep -rn "outbound safety filter"` returns no hit in **live copy** — i.e. the constant's value
+  contains none of it. Deliberate known-bad anchors in the new test's docstring and in
+  `docs/features/promise-gate.md`'s constraint-3 rationale are expected and are not violations.
 - The constant is defined in `agent/notification_copy.py` and nowhere else.
 - Ruff check and format clean.
 - **Human-facing validation (critique finding, Scope & Value):** every other criterion here is

--- a/docs/plans/terminal-flush-fallback-persona-voice.md
+++ b/docs/plans/terminal-flush-fallback-persona-voice.md
@@ -1,0 +1,24 @@
+---
+status: Planning
+type: bug
+appetite: Small
+tracking: https://github.com/tomcounsell/ai/issues/3290
+---
+
+# Terminal-flush promise fallback in Valor's voice
+
+## Problem
+## Freshness Check
+## Research
+## Prior Art
+## Appetite
+## Solution
+## Data Flow
+## Technical Approach
+## Step by Step Tasks
+## Rabbit Holes
+## No-Gos
+## Risks
+## Success Criteria
+## Documentation
+## Open Questions

--- a/docs/plans/terminal-flush-fallback-persona-voice.md
+++ b/docs/plans/terminal-flush-fallback-persona-voice.md
@@ -1,7 +1,7 @@
 ---
 status: Ready
 revision_applied: true
-revision_applied_at: 2026-09-11T09:05:42Z
+revision_applied_at: 2026-09-11T09:08:09Z
 type: bug
 appetite: Small
 tracking: https://github.com/tomcounsell/ai/issues/3290
@@ -150,10 +150,10 @@ identity in tests. Moving its definition changes no call graph.
 
 **Relocation.** Add the constant to `agent/notification_copy.py` with a docstring bullet matching
 the existing two, carrying the #3135 constraints forward into the comment so they remain
-discoverable at edit time. Delete the definition from `agent/session_health.py` and import it
-where `_gate_terminal_promise` needs it. Use a function-local import (`# noqa: PLC0415`) matching
-the existing `INTERRUPT_NO_RESUME` import style at `_deliver_terminal_interrupt_notice`, to stay
-consistent with the file and avoid any import-cycle risk.
+discoverable at edit time. Delete the definition from `agent/session_health.py` and import it at
+module level there. See "Import placement" immediately below for why module level is mandatory and
+why this deliberately does not follow the function-local `INTERRUPT_NO_RESUME` import style at
+`_deliver_terminal_interrupt_notice`.
 
 **Re-export for compatibility.** `agent.session_health.TERMINAL_PROMISE_FALLBACK_MESSAGE` is
 imported by name in `tests/unit/test_deferred_self_draft_completed.py` at **three** sites, verified
@@ -247,7 +247,7 @@ New for this issue:
 |---|---|
 | New wording trips the heuristic it is the fallback for (infinite-narrowing failure). | Verified by direct execution at plan time; locked by a test assertion. |
 | A hidden import site of the constant breaks on relocation. | Step 3 is an explicit repo-wide grep before the move is considered done. |
-| The vocabulary assertion is too blunt and blocks a legitimate future word. | Keep the banned list to the three words that caused this report, checked as substrings, with a comment explaining why each is banned. |
+| The vocabulary assertion is too blunt and blocks a legitimate future word. | Keep the banned list to the three words that caused this report, matched as a leading-`\b` word-boundary regex (never a raw substring, which false-positives on `possession`), with a comment explaining why each is banned. |
 | Reviewer reads this as reopening #3135's truth question. | Plan states explicitly that truth constraints are preserved, not revisited; the test proves it. |
 
 ## Success Criteria
@@ -348,6 +348,28 @@ found three defects introduced *by the revision itself*: 1 blocker, 2 concerns.
 
 Round 2 also confirmed the plan remains proportionate to its Small appetite: the added prose is
 reasoning about the same single-constant change, with no new file touches and no new control flow.
+
+### Round 3 (verification round, LITE)
+
+A single Consolidated Critic re-read the plan to confirm convergence. It verified all three round-2
+findings were genuinely fixed at their cited locations, and confirmed the final wording satisfies
+every No-Go. It then found the **same propagation defect class for a third time**, in two locations
+the round-2 pass had not been pointed at.
+
+| Severity | Critic | Finding | Addressed By | Implementation Note |
+|----------|--------|---------|--------------|---------------------|
+| BLOCKER | Consolidated Critic | The Technical Approach "Relocation" paragraph still carried the original "use a function-local import (`# noqa: PLC0415`)" sentence. Round 2 fixed the two *cited* locations and added the correct "Import placement" paragraph directly below, but never deleted the stale sentence that a builder reading top-to-bottom hits first. | Relocation paragraph rewritten to mandate the module-level import and cross-reference "Import placement" | The stale sentence sat immediately above the paragraph that contradicted it, which is why a cited-location fix missed it. |
+| CONCERN | Consolidated Critic | The Risks table mitigation still read "checked as substrings", a third location contradicting the word-boundary regex. | Risks table row rewritten to specify the leading-`\b` regex and name the `possession` false positive | Found only by grepping `substring` across the whole document rather than revisiting cited lines. |
+
+**Process correction adopted after round 3.** Three consecutive rounds found the identical defect
+class: a constraint changed in one section while other sections kept describing the superseded
+behavior. The cause was fixing critic-cited line numbers instead of sweeping. Both round-3 fixes
+were made by running `grep -n -i` for the *concept* across the entire plan (`function-local|PLC0415|use site|module-level`
+and `substring`) and reconciling every live hit, with the `## Critique Results` rows deliberately
+left alone as historical record. The same sweep-don't-enumerate discipline applies to the build:
+**Step 3's repo-wide grep for `TERMINAL_PROMISE_FALLBACK_MESSAGE` is the gate for the import-site
+change, not the three line numbers this plan happens to name.** Line numbers in this plan are
+navigational aids and may already have drifted; the grep is authoritative.
 
 **Scope ruling.** The Scope & Value critic was asked to rule on the Open Question below and
 judged the relocation to `agent/notification_copy.py` **justified scope, not creep** — it matches

--- a/docs/plans/terminal-flush-fallback-persona-voice.md
+++ b/docs/plans/terminal-flush-fallback-persona-voice.md
@@ -1,5 +1,7 @@
 ---
 status: Ready
+revision_applied: true
+revision_applied_at: 2026-09-11T09:01:37Z
 type: bug
 appetite: Small
 tracking: https://github.com/tomcounsell/ai/issues/3290
@@ -87,7 +89,7 @@ doc section updated. No behavior change, no new control flow.
 ### Chosen wording
 
 ```
-I didn't send my last message here. It made a commitment I couldn't back up.
+I didn't send my last message here. It didn't meet the bar I hold myself to.
 If you were waiting on something from me, just ask again.
 ```
 
@@ -96,8 +98,18 @@ Why each clause is defensible given **only** "the gate withheld the message":
 | Clause | Justification |
 |---|---|
 | "I didn't send my last message here." | Exactly what happened. First person, because Valor's own outbound check is Valor's, not a third party's. |
-| "It made a commitment I couldn't back up." | Restates the block verdict itself. Both block classes (`forward_deferral`, `behavioral_change`) are precisely "a commitment with no evidence behind it". Claims nothing about the work. |
+| "It didn't meet the bar I hold myself to." | True for **every** block class without asserting what the offending text said. See the note below on why the more specific phrasing was rejected. |
 | "If you were waiting on something from me, just ask again." | Conditional. Invents no pending request and promises no future delivery. |
+
+**Rejected phrasing, and why (critique finding, History & Consistency).** The first draft
+read "It made a commitment I couldn't back up." That is *not* entailed by a block verdict.
+The gate has two block classes, and `_BEHAVIORAL_CHANGE_PATTERNS` (`bridge/promise_gate.py:279-287`)
+matches bare acknowledgments of the *human's* statement: `you're right`, `good point`,
+`makes sense`, `point taken`, `fair point`. A message blocked for one of those made no
+commitment at all. Shipping "I made a commitment" in that case asserts something false about
+text the human never saw — which is precisely the overreach class #3135 was filed to remove.
+"It didn't meet the bar I hold myself to" is true under both block classes because the bar
+*is* the gate, so the clause is verdict-shaped rather than content-shaped.
 
 Deliberately absent: any claim about whether work completed (the #3135 trap), the words
 filter/session/gate/message-gate, em-dashes (repo rule for published text), and any
@@ -135,9 +147,23 @@ the existing `INTERRUPT_NO_RESUME` import style at `_deliver_terminal_interrupt_
 consistent with the file and avoid any import-cycle risk.
 
 **Re-export for compatibility.** `agent.session_health.TERMINAL_PROMISE_FALLBACK_MESSAGE` is
-imported by name in `tests/unit/test_deferred_self_draft_completed.py` (two sites). Per the repo's
-NO LEGACY CODE rule, do **not** leave a compatibility alias: update the test imports to the new
-canonical location instead. Verify by grep that no other module imports the name.
+imported by name in `tests/unit/test_deferred_self_draft_completed.py` at **three** sites, verified
+by grep at revision time: **L1153**, **L1217**, and **L1226** (the last is a parenthesized
+multi-name import). An earlier draft of this plan said "two sites" and its Test Impact table
+omitted L1153; two critics caught it independently. Because Step 2 deletes the constant with **no**
+compatibility alias, a missed import site is an `ImportError` at collection time that takes down
+the entire test module, not just one test. Step 3's grep is therefore a gate, not a formality.
+
+**Import placement (critique finding, Risk & Robustness).** Import the constant at **module level**
+in `agent/session_health.py`, not function-locally inside `_gate_terminal_promise`. That function
+wraps its whole body in `try: ... except Exception:` and **fail-opens by returning the original,
+un-gated message**. A function-local import that failed would therefore be swallowed into the
+fail-open path and silently deliver the very promise text the gate exists to withhold. A
+module-level import fails loudly at import time instead. There is no cycle risk:
+`agent/notification_copy.py` imports nothing but `__future__`, so it cannot import
+`session_health` back. This deliberately diverges from the function-local
+`from agent.notification_copy import INTERRUPT_NO_RESUME` at `_deliver_terminal_interrupt_notice`;
+that site is not inside a fail-open handler, so the same hazard does not apply to it.
 
 **Heuristic verification is deterministic.** The terminal-flush route always uses the regex
 `_evaluate_promise_heuristic`, never the LLM layer, so the allow/block property of the new wording
@@ -145,10 +171,17 @@ is fully testable offline with no API key. Confirmed by direct execution during 
 chosen wording returns `action="allow"`, `reason="no_promise_detected"`.
 
 **Test design.** Extend `test_substitute_message_passes_the_heuristic` into two assertions, or add
-a sibling test. The second property is a *negative vocabulary* assertion over a list of banned
-substrings (`filter`, `session`, `gate`) checked case-insensitively. This is the assertion that
-prevents a future edit silently regressing to narration; the heuristic assertion alone would not
-catch it.
+a sibling test. The second property is a *negative vocabulary* assertion over the banned terms
+`filter`, `session`, `gate`.
+
+Match on **word boundaries**, not raw substrings (critique finding, Scope & Value):
+`re.search(rf"\b{term}", text, re.IGNORECASE)`. A raw `in` check makes the guard fire on innocent
+words that merely contain a banned term — `possession` and `obsession` both contain `session` —
+so a perfectly on-persona future rewrite could fail the guard for no jargon reason. Use a leading
+`\b` only, so that inflections (`filtered`, `sessions`, `gated`) are still caught.
+
+This is the assertion that prevents a future edit silently regressing to narration; the heuristic
+assertion alone would not catch it.
 
 ## Step by Step Tasks
 
@@ -156,7 +189,9 @@ catch it.
    a module-docstring bullet, and the #3135 constraint comment.
 2. Delete the constant and its comment block from `agent/session_health.py`; import the name from
    `agent.notification_copy` inside `_gate_terminal_promise`.
-3. `grep -rn "TERMINAL_PROMISE_FALLBACK_MESSAGE"` and update every import site to the new location.
+3. `grep -rn "TERMINAL_PROMISE_FALLBACK_MESSAGE"` and update **all three** test import sites
+   (L1153, L1217, L1226) to the new location. The grep must return zero references to
+   `agent.session_health` for this name before the step is done.
 4. Extend the #3135 coverage in `tests/unit/test_deferred_self_draft_completed.py`: assert
    heuristic-allow AND absence of the banned vocabulary. Keep
    `test_async_email_fallback_promise_substituted` green (it asserts by identity, so it should be
@@ -213,6 +248,12 @@ New for this issue:
 - `grep -rn "outbound safety filter"` returns no hits.
 - The constant is defined in `agent/notification_copy.py` and nowhere else.
 - Ruff check and format clean.
+- **Human-facing validation (critique finding, Scope & Value):** every other criterion here is
+  mechanical, and the defect Tom reported is a subjective one — a regex-clean string can still read
+  as stilted. Before the PR is opened, the exact final text is read cold, as a chat message, and
+  judged on one question: does this sound like Valor talking to a teammate? The reviewer in
+  `/do-pr-review` is asked the same question explicitly. This criterion is a judgment gate, not an
+  assertion, and it is recorded here so it cannot be quietly skipped.
 
 ## Documentation
 
@@ -252,8 +293,9 @@ flush, the text the human receives changes.
 
 | Test | File | Disposition | Why |
 |---|---|---|---|
-| `test_substitute_message_passes_the_heuristic` | `tests/unit/test_deferred_self_draft_completed.py` (~L1213) | **UPDATE** | Repoint its import of `TERMINAL_PROMISE_FALLBACK_MESSAGE` to `agent.notification_copy`, and extend it with the new negative-vocabulary assertion (or add a sibling test for that property). The existing heuristic-allow assertion is kept verbatim: it is the #3135 guarantee. |
-| `test_async_email_fallback_promise_substituted` | `tests/unit/test_deferred_self_draft_completed.py` (~L1221) | **UPDATE** (import only) | Asserts the delivered text equals the constant *by identity*, not by literal string, so the wording change does not affect it. Only its import location changes. |
+| `test_promise_flagged_deferred_draft_substituted_not_delivered` | `tests/unit/test_deferred_self_draft_completed.py` (L1153) | **UPDATE** (import only) | Third import site, missed by the first draft of this plan and caught by two critics. Asserts the delivered payload equals the constant by identity, so the wording change does not affect it; only its import location moves. Missing it is an `ImportError` at collection time for the whole module. |
+| `test_substitute_message_passes_the_heuristic` | `tests/unit/test_deferred_self_draft_completed.py` (L1217) | **UPDATE** | Repoint its import of `TERMINAL_PROMISE_FALLBACK_MESSAGE` to `agent.notification_copy`, and extend it with the new negative-vocabulary assertion (or add a sibling test for that property). The existing heuristic-allow assertion is kept verbatim: it is the #3135 guarantee. |
+| `test_async_email_fallback_promise_substituted` | `tests/unit/test_deferred_self_draft_completed.py` (L1226) | **UPDATE** (import only) | Asserts the delivered text equals the constant *by identity*, not by literal string, so the wording change does not affect it. Only its import location changes. |
 | `test_promise_reply_substituted_at_terminal_flush` / kill-switch / benign-text tests | `tests/unit/test_deferred_self_draft_completed.py` | **KEEP** | Exercise gate behavior, not the fallback wording. Must stay green as the regression guard that this PR changed copy and nothing else. |
 | (new) vocabulary-guard assertion | `tests/unit/test_deferred_self_draft_completed.py` | **ADD** | Asserts the constant contains none of `filter`, `session`, `gate` (case-insensitive substring check). This is the assertion that makes the persona property durable rather than a one-time edit. |
 
@@ -266,10 +308,31 @@ No full-suite run — per `CLAUDE.md`, parallel worktrees collide on Redis state
 **Expected-failure scan:** `grep -rn 'pytest.mark.xfail\|pytest.xfail(' tests/` found no xfail
 markers related to the promise gate or terminal flush, so there is no xfail to convert.
 
+## Critique Results
+
+Critique run 2026-09-11 (FULL depth, appetite=Small): 1 blocker, 4 concerns, 1 nit. Verdict
+NEEDS REVISION. All findings addressed in this revision pass. The blocker was independently
+reported by two critics and re-verified by hand against the test file before being accepted.
+
+| Severity | Critic | Finding | Addressed By | Implementation Note |
+|----------|--------|---------|--------------|---------------------|
+| BLOCKER | History & Consistency, Risk & Robustness | Plan said the constant is imported at "two sites" in the test module; there are three (L1153, L1217, L1226). Step 2 deletes the constant with no alias, so the missed site is an `ImportError` at collection time that fails the whole module. | Technical Approach ("Re-export for compatibility" rewritten), Step 3, Test Impact (new row for L1153) | Verified by hand: `grep -n "from agent.session_health import TERMINAL_PROMISE_FALLBACK_MESSAGE"` returns L1153 and L1217; L1226 is a parenthesized multi-name import that grep for the bare name also catches. Grep for the name, not for the import line shape. |
+| CONCERN | History & Consistency | Chosen wording "It made a commitment I couldn't back up" is not entailed by a block verdict: `_BEHAVIORAL_CHANGE_PATTERNS` matches bare acknowledgments (`you're right`, `good point`, `makes sense`) that contain no commitment. Same overreach class #3135 was filed to remove. | Solution → Chosen wording (text changed to "It didn't meet the bar I hold myself to"), plus a "Rejected phrasing, and why" note | The replacement clause is verdict-shaped, not content-shaped: the bar *is* the gate, so it is true under both block classes without asserting what the withheld text said. Re-verified `action == "allow"` on the new string. |
+| CONCERN | Risk & Robustness | Plan did not say whether the new `agent.notification_copy` import goes inside `_gate_terminal_promise`'s `try` block, which catches `Exception` broadly and fail-opens by delivering the original un-gated text. | Technical Approach (new "Import placement" paragraph) | Put the import at module level in `agent/session_health.py`. Function-local inside the `try` means an ImportError is swallowed into the fail-open path and ships the promise text the gate exists to withhold. No cycle risk: `notification_copy.py` imports only `__future__`. |
+| CONCERN | Scope & Value | The negative-vocabulary guard bans `session` as a raw substring, but `possession`/`obsession` contain it, so an on-persona future wording could fail the guard for no jargon reason. | Technical Approach → Test design | Use `re.search(rf"\b{term}", text, re.IGNORECASE)`. Leading `\b` only, so inflections (`filtered`, `sessions`, `gated`) are still caught. |
+| CONCERN | Scope & Value | All Success Criteria are mechanical/regex-based; none validate the actual subjective defect Tom reported ("reads as off-persona"). The plan could satisfy every criterion and still ship stilted copy. | Success Criteria (new human-facing validation bullet) | Judgment gate, not an assertion: the final text is read cold as a chat message before the PR opens, and `/do-pr-review` is asked the same question explicitly. |
+| NIT | Scope & Value | "I didn't send my last message here" may momentarily confuse a cold reader, since the substitute is the only message they actually see. | Accepted, not changed | Any alternative that removes the ambiguity ("I wrote something and held it") asserts more about the withheld text than the verdict supports. The mild ambiguity is the cheaper cost. Recorded so a future editor does not re-litigate it blind. |
+
+**Scope ruling.** The Scope & Value critic was asked to rule on the Open Question below and
+judged the relocation to `agent/notification_copy.py` **justified scope, not creep** — it matches
+the existing #1877 convention, it is a one-constant move, and the plan gave explicit reasoning. No
+finding was raised against it. The Open Question is therefore resolved in favor of keeping the
+relocation in this PR.
+
+---
+
 ## Open Questions
 
-None blocking. One judgment call already made and recorded here for the critique to challenge:
-relocating the constant to `agent/notification_copy.py` is included in this PR rather than
-deferred, on the grounds that it is a one-constant move and that leaving it in place preserves the
-drift pressure that produced the bug. If the critique judges the relocation to be scope creep, the
-wording change alone satisfies every acceptance criterion in #3290 and the move can be dropped.
+**Resolved.** The one judgment call in this plan — whether relocating the constant to
+`agent/notification_copy.py` belongs in this PR or should be deferred — was put to the Scope &
+Value critic, which ruled it justified scope rather than creep. No open questions block the build.

--- a/docs/plans/terminal-flush-fallback-persona-voice.md
+++ b/docs/plans/terminal-flush-fallback-persona-voice.md
@@ -1,7 +1,7 @@
 ---
 status: Ready
 revision_applied: true
-revision_applied_at: 2026-09-11T09:01:37Z
+revision_applied_at: 2026-09-11T09:05:42Z
 type: bug
 appetite: Small
 tracking: https://github.com/tomcounsell/ai/issues/3290
@@ -82,14 +82,16 @@ doc section updated. No behavior change, no new control flow.
 
 1. Rewrite the constant in first-person Valor voice.
 2. Relocate it from `agent/session_health.py` to `agent/notification_copy.py`, joining
-   `INTERRUPT_NO_RESUME` and `FAILURE_NOTICE` under the #1877 contract. Import it at its use site.
+   `INTERRUPT_NO_RESUME` and `FAILURE_NOTICE` under the #1877 contract. Import it at **module level**
+   in `agent/session_health.py` (see "Import placement" under Technical Approach for why it must not
+   be function-local).
 3. Extend the existing #3135 test with a second property: the text is free of internal vocabulary.
 4. Update `docs/features/promise-gate.md` where it quotes the old string.
 
 ### Chosen wording
 
 ```
-I didn't send my last message here. It didn't meet the bar I hold myself to.
+I didn't send my last message here. It wasn't good enough.
 If you were waiting on something from me, just ask again.
 ```
 
@@ -98,7 +100,7 @@ Why each clause is defensible given **only** "the gate withheld the message":
 | Clause | Justification |
 |---|---|
 | "I didn't send my last message here." | Exactly what happened. First person, because Valor's own outbound check is Valor's, not a third party's. |
-| "It didn't meet the bar I hold myself to." | True for **every** block class without asserting what the offending text said. See the note below on why the more specific phrasing was rejected. |
+| "It wasn't good enough." | True for **every** block class without asserting what the offending text said. "It" is bound to "my last message" by the preceding sentence, so this says the *message* fell short, never the work. See the notes below on the two phrasings that were rejected. |
 | "If you were waiting on something from me, just ask again." | Conditional. Invents no pending request and promises no future delivery. |
 
 **Rejected phrasing, and why (critique finding, History & Consistency).** The first draft
@@ -108,8 +110,15 @@ matches bare acknowledgments of the *human's* statement: `you're right`, `good p
 `makes sense`, `point taken`, `fair point`. A message blocked for one of those made no
 commitment at all. Shipping "I made a commitment" in that case asserts something false about
 text the human never saw — which is precisely the overreach class #3135 was filed to remove.
-"It didn't meet the bar I hold myself to" is true under both block classes because the bar
-*is* the gate, so the clause is verdict-shaped rather than content-shaped.
+The replacement is true under both block classes because it is verdict-shaped rather than
+content-shaped: it reports that the message failed Valor's own outbound standard, without
+characterizing what the message said.
+
+**Second rejected phrasing, and why (critique round 2, Scope & Value).** The first revision used
+"It didn't meet the bar I hold myself to." That is truthful, but read cold as a chat message it
+is performative — it narrates a standard instead of just saying the thing, which is a subtler form
+of the same off-persona problem Tom reported. "It wasn't good enough." is what a person actually
+says. It carries identical truth constraints and is four words instead of nine.
 
 Deliberately absent: any claim about whether work completed (the #3135 trap), the words
 filter/session/gate/message-gate, em-dashes (repo rule for published text), and any
@@ -187,8 +196,10 @@ assertion alone would not catch it.
 
 1. Add `TERMINAL_PROMISE_FALLBACK_MESSAGE` to `agent/notification_copy.py` with the new wording,
    a module-docstring bullet, and the #3135 constraint comment.
-2. Delete the constant and its comment block from `agent/session_health.py`; import the name from
-   `agent.notification_copy` inside `_gate_terminal_promise`.
+2. Delete the constant and its comment block from `agent/session_health.py`; add a **module-level**
+   `from agent.notification_copy import TERMINAL_PROMISE_FALLBACK_MESSAGE` at the top of
+   `agent/session_health.py`. Do NOT put this import inside `_gate_terminal_promise` — that function
+   fail-opens on `Exception` and would swallow an ImportError into the un-gated delivery path.
 3. `grep -rn "TERMINAL_PROMISE_FALLBACK_MESSAGE"` and update **all three** test import sites
    (L1153, L1217, L1226) to the new location. The grep must return zero references to
    `agent.session_health` for this name before the step is done.
@@ -297,7 +308,7 @@ flush, the text the human receives changes.
 | `test_substitute_message_passes_the_heuristic` | `tests/unit/test_deferred_self_draft_completed.py` (L1217) | **UPDATE** | Repoint its import of `TERMINAL_PROMISE_FALLBACK_MESSAGE` to `agent.notification_copy`, and extend it with the new negative-vocabulary assertion (or add a sibling test for that property). The existing heuristic-allow assertion is kept verbatim: it is the #3135 guarantee. |
 | `test_async_email_fallback_promise_substituted` | `tests/unit/test_deferred_self_draft_completed.py` (L1226) | **UPDATE** (import only) | Asserts the delivered text equals the constant *by identity*, not by literal string, so the wording change does not affect it. Only its import location changes. |
 | `test_promise_reply_substituted_at_terminal_flush` / kill-switch / benign-text tests | `tests/unit/test_deferred_self_draft_completed.py` | **KEEP** | Exercise gate behavior, not the fallback wording. Must stay green as the regression guard that this PR changed copy and nothing else. |
-| (new) vocabulary-guard assertion | `tests/unit/test_deferred_self_draft_completed.py` | **ADD** | Asserts the constant contains none of `filter`, `session`, `gate` (case-insensitive substring check). This is the assertion that makes the persona property durable rather than a one-time edit. |
+| (new) vocabulary-guard assertion | `tests/unit/test_deferred_self_draft_completed.py` | **ADD** | Asserts the constant matches none of `filter`, `session`, `gate` as a **case-insensitive word-boundary regex** (`re.search(rf"\b{term}", text, re.IGNORECASE)`), NOT a raw substring check — a substring check false-positives on `possession`/`obsession`. This is the assertion that makes the persona property durable rather than a one-time edit. |
 
 **No DELETE / REPLACE dispositions.** No existing test becomes obsolete; #3135's coverage is
 preserved in full and extended.
@@ -317,11 +328,26 @@ reported by two critics and re-verified by hand against the test file before bei
 | Severity | Critic | Finding | Addressed By | Implementation Note |
 |----------|--------|---------|--------------|---------------------|
 | BLOCKER | History & Consistency, Risk & Robustness | Plan said the constant is imported at "two sites" in the test module; there are three (L1153, L1217, L1226). Step 2 deletes the constant with no alias, so the missed site is an `ImportError` at collection time that fails the whole module. | Technical Approach ("Re-export for compatibility" rewritten), Step 3, Test Impact (new row for L1153) | Verified by hand: `grep -n "from agent.session_health import TERMINAL_PROMISE_FALLBACK_MESSAGE"` returns L1153 and L1217; L1226 is a parenthesized multi-name import that grep for the bare name also catches. Grep for the name, not for the import line shape. |
-| CONCERN | History & Consistency | Chosen wording "It made a commitment I couldn't back up" is not entailed by a block verdict: `_BEHAVIORAL_CHANGE_PATTERNS` matches bare acknowledgments (`you're right`, `good point`, `makes sense`) that contain no commitment. Same overreach class #3135 was filed to remove. | Solution → Chosen wording (text changed to "It didn't meet the bar I hold myself to"), plus a "Rejected phrasing, and why" note | The replacement clause is verdict-shaped, not content-shaped: the bar *is* the gate, so it is true under both block classes without asserting what the withheld text said. Re-verified `action == "allow"` on the new string. |
+| CONCERN | History & Consistency | Chosen wording "It made a commitment I couldn't back up" is not entailed by a block verdict: `_BEHAVIORAL_CHANGE_PATTERNS` matches bare acknowledgments (`you're right`, `good point`, `makes sense`) that contain no commitment. Same overreach class #3135 was filed to remove. | Solution → Chosen wording (superseded in round 2; final text is "It wasn't good enough."), plus a "Rejected phrasing, and why" note | The replacement clause is verdict-shaped, not content-shaped: the bar *is* the gate, so it is true under both block classes without asserting what the withheld text said. Re-verified `action == "allow"` on the new string. |
 | CONCERN | Risk & Robustness | Plan did not say whether the new `agent.notification_copy` import goes inside `_gate_terminal_promise`'s `try` block, which catches `Exception` broadly and fail-opens by delivering the original un-gated text. | Technical Approach (new "Import placement" paragraph) | Put the import at module level in `agent/session_health.py`. Function-local inside the `try` means an ImportError is swallowed into the fail-open path and ships the promise text the gate exists to withhold. No cycle risk: `notification_copy.py` imports only `__future__`. |
 | CONCERN | Scope & Value | The negative-vocabulary guard bans `session` as a raw substring, but `possession`/`obsession` contain it, so an on-persona future wording could fail the guard for no jargon reason. | Technical Approach → Test design | Use `re.search(rf"\b{term}", text, re.IGNORECASE)`. Leading `\b` only, so inflections (`filtered`, `sessions`, `gated`) are still caught. |
 | CONCERN | Scope & Value | All Success Criteria are mechanical/regex-based; none validate the actual subjective defect Tom reported ("reads as off-persona"). The plan could satisfy every criterion and still ship stilted copy. | Success Criteria (new human-facing validation bullet) | Judgment gate, not an assertion: the final text is read cold as a chat message before the PR opens, and `/do-pr-review` is asked the same question explicitly. |
 | NIT | Scope & Value | "I didn't send my last message here" may momentarily confuse a cold reader, since the substitute is the only message they actually see. | Accepted, not changed | Any alternative that removes the ambiguity ("I wrote something and held it") asserts more about the withheld text than the verdict supports. The mild ambiguity is the cheaper cost. Recorded so a future editor does not re-litigate it blind. |
+
+### Round 2 (re-critique of the revised plan)
+
+All three round-1 critics re-ran against the revised plan and **verified the round-1 findings were
+genuinely resolved in the revision text**, not merely acknowledged in the table above. Round 2 then
+found three defects introduced *by the revision itself*: 1 blocker, 2 concerns.
+
+| Severity | Critic | Finding | Addressed By | Implementation Note |
+|----------|--------|---------|--------------|---------------------|
+| BLOCKER | History & Consistency | The new "Import placement" paragraph mandates a module-level import, but Solution item 2 ("Import it at its use site") and Step 2 ("import the name from `agent.notification_copy` inside `_gate_terminal_promise`") were never updated to match. The plan instructed the builder to do the exact thing the new paragraph forbids. | Solution item 2 and Step 2 both rewritten to mandate the module-level import and to name the hazard explicitly | Self-inflicted by the round-1 revision: a new constraint was added in one section without propagating to the two sections that already described the old behavior. Confirmed by grep at lines 85 and 191 before fixing. |
+| CONCERN | Risk & Robustness | The Test Impact row for the new vocabulary guard still said "case-insensitive substring check", contradicting the Technical Approach fix that replaced substrings with a word-boundary regex specifically to kill the `possession`/`obsession` false positive. | Test Impact table row rewritten to specify the word-boundary regex and to name the rejected substring approach | Same propagation failure as the blocker: the fix landed in Technical Approach only. The table row is what a builder skims, so it had to carry the corrected form too. |
+| CONCERN | Scope & Value | The round-1 replacement wording, "It didn't meet the bar I hold myself to", is truthful but reads as performative when received cold as a chat message: it narrates a standard rather than simply stating the fact. That is a subtler instance of the same off-persona problem Tom reported. | Solution → Chosen wording (now "It wasn't good enough."), plus a "Second rejected phrasing" note | Identical truth constraints, four words instead of nine. Re-verified: `action == "allow"`, no banned term matches the word-boundary regex, no em-dash. |
+
+Round 2 also confirmed the plan remains proportionate to its Small appetite: the added prose is
+reasoning about the same single-constant change, with no new file touches and no new control flow.
 
 **Scope ruling.** The Scope & Value critic was asked to rule on the Open Question below and
 judged the relocation to `agent/notification_copy.py` **justified scope, not creep** — it matches

--- a/docs/plans/terminal-flush-fallback-persona-voice.md
+++ b/docs/plans/terminal-flush-fallback-persona-voice.md
@@ -216,12 +216,55 @@ New for this issue:
 
 ## Documentation
 
-- `docs/features/promise-gate.md` — Terminal flush section: replace the quoted string, and state
-  the persona-voice constraint next to the existing truth constraint so a future editor sees both.
-- `agent/notification_copy.py` — module docstring gains a bullet for the new constant.
+- [ ] `docs/features/promise-gate.md` — Terminal flush section (~line 79): replace the quoted
+      string with the new wording, and state the persona-voice constraint next to the existing
+      truth constraint so a future editor sees both. This is the only doc in `docs/features/` that
+      quotes the constant.
+- [ ] `agent/notification_copy.py` — module docstring gains a bullet for the new constant, matching
+      the format of the existing `INTERRUPT_NO_RESUME` / `FAILURE_NOTICE` bullets.
 
 No new `docs/infra/` doc: this plan adds no dependency, service, external API call, or deployment
 change.
+
+## Update System
+
+**No migration required.** This plan touches no Popoto model, no model field, and no Redis key
+shape. It changes one module-level string constant and its defining module. `scripts/update/migrations.py`
+needs no new entry and `MIGRATIONS` is unmodified.
+
+No raw Redis operations are introduced; the plan does not touch persistence at all.
+
+**Deploy note (not a migration):** the constant is read in-process by the worker, so the new
+wording takes effect for running services only after `./scripts/valor-service.sh restart`, which
+`/update` performs on the standard post-merge path. No special deploy step beyond that.
+
+## Agent Integration
+
+**No MCP exposure required.** This plan adds no Python tool, no CLI entrypoint, and no callable
+surface. It relocates one string constant between two existing modules. There is nothing for an
+agent to invoke, so no MCP server registration, no `tools/` addition, and no
+`docs/tools-reference.md` entry.
+
+The only agent-visible effect is indirect and intended: when the promise gate blocks a terminal
+flush, the text the human receives changes.
+
+## Test Impact
+
+| Test | File | Disposition | Why |
+|---|---|---|---|
+| `test_substitute_message_passes_the_heuristic` | `tests/unit/test_deferred_self_draft_completed.py` (~L1213) | **UPDATE** | Repoint its import of `TERMINAL_PROMISE_FALLBACK_MESSAGE` to `agent.notification_copy`, and extend it with the new negative-vocabulary assertion (or add a sibling test for that property). The existing heuristic-allow assertion is kept verbatim: it is the #3135 guarantee. |
+| `test_async_email_fallback_promise_substituted` | `tests/unit/test_deferred_self_draft_completed.py` (~L1221) | **UPDATE** (import only) | Asserts the delivered text equals the constant *by identity*, not by literal string, so the wording change does not affect it. Only its import location changes. |
+| `test_promise_reply_substituted_at_terminal_flush` / kill-switch / benign-text tests | `tests/unit/test_deferred_self_draft_completed.py` | **KEEP** | Exercise gate behavior, not the fallback wording. Must stay green as the regression guard that this PR changed copy and nothing else. |
+| (new) vocabulary-guard assertion | `tests/unit/test_deferred_self_draft_completed.py` | **ADD** | Asserts the constant contains none of `filter`, `session`, `gate` (case-insensitive substring check). This is the assertion that makes the persona property durable rather than a one-time edit. |
+
+**No DELETE / REPLACE dispositions.** No existing test becomes obsolete; #3135's coverage is
+preserved in full and extended.
+
+**Narrow run command:** `scripts/pytest-clean.sh tests/unit/test_deferred_self_draft_completed.py`.
+No full-suite run — per `CLAUDE.md`, parallel worktrees collide on Redis state.
+
+**Expected-failure scan:** `grep -rn 'pytest.mark.xfail\|pytest.xfail(' tests/` found no xfail
+markers related to the promise gate or terminal flush, so there is no xfail to convert.
 
 ## Open Questions
 

--- a/docs/plans/terminal-flush-fallback-persona-voice.md
+++ b/docs/plans/terminal-flush-fallback-persona-voice.md
@@ -1,5 +1,5 @@
 ---
-status: Planning
+status: Ready
 type: bug
 appetite: Small
 tracking: https://github.com/tomcounsell/ai/issues/3290
@@ -8,17 +8,225 @@ tracking: https://github.com/tomcounsell/ai/issues/3290
 # Terminal-flush promise fallback in Valor's voice
 
 ## Problem
+
+When the promise gate blocks a session's held final reply at terminal-flush time, there is no
+live agent left to redraft it, so `agent/session_health._gate_terminal_promise` substitutes a
+fixed constant, `TERMINAL_PROMISE_FALLBACK_MESSAGE`. That constant is delivered verbatim to the
+human in Telegram and reads as a system bulletin, not as Valor:
+
+> An outbound safety filter held back this session's final message. The work may have finished
+> normally; if something you expected is missing, ask again in a new message.
+
+Tom received this in the **Eng: Valor** group (thread `tg_valor_-1003449100931_1457`) and flagged
+it as off-persona. It violates the standing `CLAUDE.md` rule that no raw error or internal
+narration reaches the human: it names an internal mechanism ("outbound safety filter"), uses
+internal vocabulary ("this session's final message"), and speaks about Valor in the third person
+instead of as Valor.
+
+**Current behavior:** gate blocks a terminal-flush reply, human gets machine narration.
+
+**Desired outcome:** human gets a short first-person message that reads as Valor talking to a
+teammate, names no filter / session / gate, asserts nothing the system cannot verify, and still
+returns `allow` from `_evaluate_promise_heuristic`.
+
 ## Freshness Check
+
+**Disposition: Unchanged.** Baseline `e75a7aebb` (main). Issue #3290 was filed minutes before this
+plan, and its recon was performed by direct read of the code at that same baseline, so there is no
+drift window. Re-verified at plan time:
+
+- `agent/session_health.py:2537` — constant present with the exact quoted text.
+- `docs/features/promise-gate.md:79` — the only other occurrence of the literal.
+- `#3135` confirmed CLOSED; its two constraints are carried forward as a code comment at
+  `agent/session_health.py:2530-2536`, so they are live constraints and not merely issue history.
+- No commits have landed on `agent/session_health.py`, `agent/notification_copy.py`,
+  `bridge/promise_gate.py`, or `tests/unit/test_deferred_self_draft_completed.py` since the issue
+  was filed.
+- No active plan in `docs/plans/` touches the promise gate or the terminal-flush path. No overlap.
+
+Bug still reproducible by inspection: the constant is unconditionally returned on a `block`
+verdict, so any blocked terminal flush delivers exactly this text.
+
 ## Research
+
+No external research performed. This is purely internal copy and a constant relocation inside this
+repo. No libraries, APIs, or ecosystem patterns are involved. Proceeding on codebase context.
+
 ## Prior Art
+
+- **#3135 (closed)** — fixed the *truth* defect in this same constant. The prior wording asserted
+  the session's work had failed, which a block verdict cannot know; a cleanly-completed session was
+  telling the human its work didn't finish. The fix corrected the claim and left the register
+  untouched. Its two constraints must survive this change and are restated under No-Gos.
+- **#2423** — established the substitution-over-suppression design for this route. Suppression was
+  rejected because it reintroduces the #1796 swallowed-reply class. This plan does not reopen that.
+- **#1877** — established `agent/notification_copy.py` as the single source of truth for
+  user-facing session-lifecycle copy, with the contract "send sites import these names; they never
+  inline the literal string". This is the convention `TERMINAL_PROMISE_FALLBACK_MESSAGE` is
+  currently outside of.
+
+**Why the previous fix was incomplete:** #3135 correctly scoped itself to truth, treating the text
+as a payload to be made accurate rather than as human-facing copy subject to the persona rule. The
+mechanical reason the register drifted is that the constant lives in `session_health.py` among
+control-flow helpers, not in `notification_copy.py` beside the two constants that set the voice.
+Fixing only the words without moving the constant leaves that drift pressure in place.
+
 ## Appetite
+
+**Small.** One constant reworded and relocated, its import sites updated, one test extended, one
+doc section updated. No behavior change, no new control flow.
+
 ## Solution
+
+1. Rewrite the constant in first-person Valor voice.
+2. Relocate it from `agent/session_health.py` to `agent/notification_copy.py`, joining
+   `INTERRUPT_NO_RESUME` and `FAILURE_NOTICE` under the #1877 contract. Import it at its use site.
+3. Extend the existing #3135 test with a second property: the text is free of internal vocabulary.
+4. Update `docs/features/promise-gate.md` where it quotes the old string.
+
+### Chosen wording
+
+```
+I didn't send my last message here. It made a commitment I couldn't back up.
+If you were waiting on something from me, just ask again.
+```
+
+Why each clause is defensible given **only** "the gate withheld the message":
+
+| Clause | Justification |
+|---|---|
+| "I didn't send my last message here." | Exactly what happened. First person, because Valor's own outbound check is Valor's, not a third party's. |
+| "It made a commitment I couldn't back up." | Restates the block verdict itself. Both block classes (`forward_deferral`, `behavioral_change`) are precisely "a commitment with no evidence behind it". Claims nothing about the work. |
+| "If you were waiting on something from me, just ask again." | Conditional. Invents no pending request and promises no future delivery. |
+
+Deliberately absent: any claim about whether work completed (the #3135 trap), the words
+filter/session/gate/message-gate, em-dashes (repo rule for published text), and any
+forward-deferral phrasing the heuristic blocks.
+
 ## Data Flow
+
+Unchanged by this plan; recorded so the reviewer can confirm the blast radius is one constant.
+
+```
+held self-draft reply
+  -> finalize_session (models/session_lifecycle.py)
+     -> agent/session_health.flush_deferred_self_draft_sync      [telegram, sync, no event loop]
+     -> agent/session_health._deliver_deferred_self_draft_fallback [email, async]
+        both call:
+        -> _gate_terminal_promise(text, transport=..., session_id=...)
+           -> bridge.promise_gate._evaluate_promise_heuristic(text)   [regex only, never LLM]
+              verdict.action == "block"
+                -> return TERMINAL_PROMISE_FALLBACK_MESSAGE   <-- the only thing changing
+              verdict.action == "allow"
+                -> return text unchanged
+  -> rpush to outbox -> bridge -> Telegram / email
+```
+
+The constant is read at exactly one site (`_gate_terminal_promise`'s block branch) and asserted by
+identity in tests. Moving its definition changes no call graph.
+
 ## Technical Approach
+
+**Relocation.** Add the constant to `agent/notification_copy.py` with a docstring bullet matching
+the existing two, carrying the #3135 constraints forward into the comment so they remain
+discoverable at edit time. Delete the definition from `agent/session_health.py` and import it
+where `_gate_terminal_promise` needs it. Use a function-local import (`# noqa: PLC0415`) matching
+the existing `INTERRUPT_NO_RESUME` import style at `_deliver_terminal_interrupt_notice`, to stay
+consistent with the file and avoid any import-cycle risk.
+
+**Re-export for compatibility.** `agent.session_health.TERMINAL_PROMISE_FALLBACK_MESSAGE` is
+imported by name in `tests/unit/test_deferred_self_draft_completed.py` (two sites). Per the repo's
+NO LEGACY CODE rule, do **not** leave a compatibility alias: update the test imports to the new
+canonical location instead. Verify by grep that no other module imports the name.
+
+**Heuristic verification is deterministic.** The terminal-flush route always uses the regex
+`_evaluate_promise_heuristic`, never the LLM layer, so the allow/block property of the new wording
+is fully testable offline with no API key. Confirmed by direct execution during planning: the
+chosen wording returns `action="allow"`, `reason="no_promise_detected"`.
+
+**Test design.** Extend `test_substitute_message_passes_the_heuristic` into two assertions, or add
+a sibling test. The second property is a *negative vocabulary* assertion over a list of banned
+substrings (`filter`, `session`, `gate`) checked case-insensitively. This is the assertion that
+prevents a future edit silently regressing to narration; the heuristic assertion alone would not
+catch it.
+
 ## Step by Step Tasks
+
+1. Add `TERMINAL_PROMISE_FALLBACK_MESSAGE` to `agent/notification_copy.py` with the new wording,
+   a module-docstring bullet, and the #3135 constraint comment.
+2. Delete the constant and its comment block from `agent/session_health.py`; import the name from
+   `agent.notification_copy` inside `_gate_terminal_promise`.
+3. `grep -rn "TERMINAL_PROMISE_FALLBACK_MESSAGE"` and update every import site to the new location.
+4. Extend the #3135 coverage in `tests/unit/test_deferred_self_draft_completed.py`: assert
+   heuristic-allow AND absence of the banned vocabulary. Keep
+   `test_async_email_fallback_promise_substituted` green (it asserts by identity, so it should be
+   unaffected once its import is repointed).
+5. Update `docs/features/promise-gate.md` Terminal flush section (~line 79) to quote the new
+   string and describe the voice constraint alongside the truth constraint.
+6. `grep -rn "outbound safety filter"` returns nothing.
+7. `python -m ruff check` and `python -m ruff format`.
+8. Narrow test run: `scripts/pytest-clean.sh tests/unit/test_deferred_self_draft_completed.py`.
+
 ## Rabbit Holes
+
+- **Rewriting the promise heuristic.** Tempting, since the gate's pattern list is what constrains
+  natural phrasing. Out of scope; the chosen wording already passes.
+- **Auditing every other outbound string for persona voice.** A real concern but a different piece
+  of work. If this PR's grep surfaces other off-persona human-facing constants, note them for a
+  follow-up issue rather than fixing them here.
+- **Making the email and Telegram routes say different things.** They share one constant today and
+  should keep sharing it.
+
 ## No-Gos
+
+Carried forward from #3135 and non-negotiable:
+
+- The fallback must NOT claim the session's work failed, succeeded, or is incomplete. A block
+  verdict carries no information about work completion.
+- The fallback must NOT invent a pending request or imply the human asked for something specific.
+- The fallback must NOT itself be an empty promise: `_evaluate_promise_heuristic(...)` must return
+  `action == "allow"`.
+
+New for this issue:
+
+- No mention of filters, sessions, gates, or any internal mechanism.
+- No em-dashes (repo rule for published text).
+- No compatibility alias left behind at the old location.
+- No change to gate behavior: substitution stays substitution, the kill switch and fail-open paths
+  are untouched.
+
 ## Risks
+
+| Risk | Mitigation |
+|---|---|
+| New wording trips the heuristic it is the fallback for (infinite-narrowing failure). | Verified by direct execution at plan time; locked by a test assertion. |
+| A hidden import site of the constant breaks on relocation. | Step 3 is an explicit repo-wide grep before the move is considered done. |
+| The vocabulary assertion is too blunt and blocks a legitimate future word. | Keep the banned list to the three words that caused this report, checked as substrings, with a comment explaining why each is banned. |
+| Reviewer reads this as reopening #3135's truth question. | Plan states explicitly that truth constraints are preserved, not revisited; the test proves it. |
+
 ## Success Criteria
+
+- `_evaluate_promise_heuristic(TERMINAL_PROMISE_FALLBACK_MESSAGE).action == "allow"`.
+- A test asserts the text contains none of `filter`, `session`, `gate` (case-insensitive).
+- All pre-existing tests in `tests/unit/test_deferred_self_draft_completed.py` pass, including both
+  #3135 tests.
+- `grep -rn "outbound safety filter"` returns no hits.
+- The constant is defined in `agent/notification_copy.py` and nowhere else.
+- Ruff check and format clean.
+
 ## Documentation
+
+- `docs/features/promise-gate.md` — Terminal flush section: replace the quoted string, and state
+  the persona-voice constraint next to the existing truth constraint so a future editor sees both.
+- `agent/notification_copy.py` — module docstring gains a bullet for the new constant.
+
+No new `docs/infra/` doc: this plan adds no dependency, service, external API call, or deployment
+change.
+
 ## Open Questions
+
+None blocking. One judgment call already made and recorded here for the critique to challenge:
+relocating the constant to `agent/notification_copy.py` is included in this PR rather than
+deferred, on the grounds that it is a one-constant move and that leaving it in place preserves the
+drift pressure that produced the bug. If the critique judges the relocation to be scope creep, the
+wording change alone satisfies every acceptance criterion in #3290 and the move can be dropped.

--- a/tests/unit/test_deferred_self_draft_completed.py
+++ b/tests/unit/test_deferred_self_draft_completed.py
@@ -1150,7 +1150,7 @@ class TestTerminalFlushPromiseGate:
     def test_promise_flagged_deferred_draft_substituted_not_delivered(self, cleanup):
         """A promise-flagged deferred draft reaching the terminal flush is NOT
         delivered verbatim; the honest-fallback substitution ships instead."""
-        from agent.session_health import TERMINAL_PROMISE_FALLBACK_MESSAGE
+        from agent.notification_copy import TERMINAL_PROMISE_FALLBACK_MESSAGE
 
         sid = f"{SID_PREFIX}promise-sub"
         cleanup.append(sid)
@@ -1214,19 +1214,42 @@ class TestTerminalFlushPromiseGate:
     def test_substitute_message_passes_the_heuristic(self):
         """The honest fallback must itself pass the promise heuristic — the
         substitution may never be a new empty promise."""
-        from agent.session_health import TERMINAL_PROMISE_FALLBACK_MESSAGE
+        from agent.notification_copy import TERMINAL_PROMISE_FALLBACK_MESSAGE
         from bridge.promise_gate import _evaluate_promise_heuristic
 
         assert _evaluate_promise_heuristic(TERMINAL_PROMISE_FALLBACK_MESSAGE).action == "allow"
+
+    def test_substitute_message_names_no_internal_mechanism(self):
+        """#3290: the fallback reaches the human in Telegram, so it must read as
+        Valor speaking, not as system narration.
+
+        The heuristic assertion above cannot catch this — the pre-#3290 wording
+        ("An outbound safety filter held back this session's final message")
+        passed the heuristic and was still raw narration that the principal
+        flagged as off-persona.
+
+        Word-boundary matching, not a raw substring check: "possession" and
+        "obsession" both contain "session", so a substring check would fail an
+        on-persona future rewrite for no jargon reason. The leading \b only
+        (no trailing \b) still catches inflections like "filtered", "sessions",
+        and "gated".
+        """
+        import re
+
+        from agent.notification_copy import TERMINAL_PROMISE_FALLBACK_MESSAGE
+
+        msg = TERMINAL_PROMISE_FALLBACK_MESSAGE
+        for term in ("filter", "session", "gate"):
+            assert not re.search(rf"\b{term}", msg, re.IGNORECASE), (
+                f"fallback names the internal mechanism {term!r}: {msg!r}"
+            )
 
     @pytest.mark.asyncio
     async def test_async_email_fallback_promise_substituted(self, cleanup):
         """The async email fallback (_deliver_deferred_self_draft_fallback) has
         the identical hole and is gated by the same helper."""
-        from agent.session_health import (
-            TERMINAL_PROMISE_FALLBACK_MESSAGE,
-            _deliver_deferred_self_draft_fallback,
-        )
+        from agent.notification_copy import TERMINAL_PROMISE_FALLBACK_MESSAGE
+        from agent.session_health import _deliver_deferred_self_draft_fallback
 
         sid = f"{SID_PREFIX}promise-async-email"
         cleanup.append(sid)


### PR DESCRIPTION
Closes #3290

## What this fixes

`TERMINAL_PROMISE_FALLBACK_MESSAGE` is delivered verbatim to the human in Telegram when the promise gate withholds a session's held final reply at terminal-flush time. It read as a system bulletin:

> An outbound safety filter held back this session's final message. The work may have finished normally; if something you expected is missing, ask again in a new message.

Tom flagged it as off-persona in the Eng: Valor group. It names an internal mechanism, uses internal vocabulary ("session"), and speaks about Valor in the third person, against the standing rule that no raw error or internal narration reaches the human.

**New wording:**

> I didn't send my last message here. It wasn't good enough. If you were waiting on something from me, just ask again.

## The part worth reviewing carefully

The clause is deliberately **verdict-shaped, not content-shaped**. My first draft said *"It made a commitment I couldn't back up."* A critic caught that this is **false** for one of the gate's two block classes: `_BEHAVIORAL_CHANGE_PATTERNS` fires on bare acknowledgments of the human's statement (`you're right`, `good point`, `makes sense`) that contain no commitment at all. Shipping "I made a commitment" in that case asserts something untrue about a message the human never saw, which is exactly the overreach class #3135 was filed to eliminate.

"It wasn't good enough" reports that the message failed Valor's own outbound standard without characterizing what it said, so it holds under both block classes.

A second draft, *"It didn't meet the bar I hold myself to,"* was also rejected: truthful, but read cold as a chat message it narrates a standard rather than stating the fact, which is a subtler form of the same off-persona problem.

## Relocation to `notification_copy.py`

`agent/notification_copy.py` declares itself the single source of truth for user-facing lifecycle copy (#1877), and its two existing constants are already correct persona voice. This constant was the same category living among control-flow helpers in `session_health.py`, which is plausibly the mechanical reason the register drifted: it never sat beside the examples that set the voice.

The import is **module-level, not function-local**. `_gate_terminal_promise` wraps its body in a broad `except Exception` that fail-opens by delivering the original text. A function-local `ImportError` would be swallowed into that path and ship the very promise text the gate exists to withhold.

## Test evidence

`test_substitute_message_names_no_internal_mechanism` was **proven RED against the known-bad wording**. With the pre-#3290 string restored:

```
tests/unit/test_deferred_self_draft_completed.py
  test_substitute_message_passes_the_heuristic ............ PASSED
  test_substitute_message_names_no_internal_mechanism ...... FAILED
  AssertionError: fallback names the internal mechanism 'filter'
```

That is the gap it closes: the #3135 heuristic test passed the off-persona string happily. The guard matches on word boundaries, so `possession` / `obsession` do not false-positive on `session`.

Full narrow run: **55 passed** (`scripts/pytest-clean.sh tests/unit/test_deferred_self_draft_completed.py`). Both #3135 tests still green. `ruff check` and `ruff format` clean.

## Notes for the reviewer

- **Judgment call I'd like a second opinion on:** does the new text actually sound like a person? The plan records this as an explicit non-mechanical acceptance criterion, because every other criterion here is a regex and the defect being fixed is subjective.
- Three mentions of the old string remain on purpose: the known-bad anchor in the new test's docstring, the constraint-3 rationale in `docs/features/promise-gate.md`, and the plan's problem statement. Naming the exact wording that violated the rule is what stops a future editor reintroducing it. The issue's acceptance criterion was tightened to say "no hit in live copy" rather than leaving it silently unmet.
- **Deliberately out of scope:** routing terminal flush through the drafter/persona layer instead of a bare constant. The drafter assumes a live agent and an LLM call, and the entire reason this fallback exists is the #2423 constraint that at terminal-flush time no live agent remains. Recorded in #3290's solution sketch as a follow-up candidate.
- The plan doc is on this branch rather than `main`, contrary to the usual plans-on-main convention, because this run was instructed not to push to `main`.

## Pipeline

Plan: `docs/plans/terminal-flush-fallback-persona-voice.md`. Critique ran three rounds (FULL, FULL, LITE verification) and is recorded in the plan's `## Critique Results` table: 1 blocker + 4 concerns + 1 nit, then 1 blocker + 2 concerns, then 1 blocker + 1 concern. All addressed. Rounds 2 and 3 each found the *same* defect class introduced by the previous round's revision (a constraint changed in one section while other sections kept describing the superseded behavior); round 3's fixes were made by grep sweep rather than by patching cited line numbers, and that correction is written into the plan.
